### PR TITLE
Add rate-limited chat interface

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -19,6 +19,12 @@
     .card-counter { display: flex; align-items: center; justify-content: space-between; padding: 1rem; color: #fff; }
     .card-counter .icon { font-size: 2rem; opacity: .7; }
     .card-counter .count { font-size: 1.75rem; font-weight: bold; }
+    .chat-card { background:#1e1e2f; box-shadow:0 0 10px 2px rgba(128,0,255,0.6); }
+    #chat-container { height:300px; overflow-y:auto; padding:0.5rem; }
+    .message { padding:0.25rem 0.5rem; margin-bottom:0.25rem; border-radius:4px; }
+    .message-user { background:#4b0082; color:#fff; text-align:right; }
+    .message-ai { background:#333; color:#fff; }
+    .message-system { background:#222; color:#e0e0e0; font-style:italic; }
   </style>
 </head>
 <body>
@@ -134,6 +140,16 @@
         </table>
       </div>
     </div>
+    <div class="mt-4">
+      <h2>Chat Demo</h2>
+      <div class="card chat-card text-light">
+        <div id="chat-container" class="mb-2" aria-live="polite" role="log"></div>
+        <form id="chat-form" class="d-flex">
+          <input id="chat-input" type="text" class="form-control me-2" placeholder="Type a message..." aria-label="chat input" disabled>
+          <button id="send-button" class="btn btn-primary" type="submit" disabled>Send</button>
+        </form>
+      </div>
+    </div>
   </main>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-ENjdO4Dr2bkBIFxQpeoYz1CnGdZXQ7YKj+47HCsHEB2z9vOo5dKZ7HisZV64VAN2" crossorigin="anonymous"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.3.0/chart.umd.min.js" integrity="sha512-pHTWx2cjYLuQHtyQpSkXw3tI+pBcj+oZ7qwy3Lf2XyZDjWzB+dpftafJ+zI74hiL2rOHYNOiLmKTjaezJ4+MaA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
@@ -196,5 +212,6 @@
       document.getElementById('refreshBtn').addEventListener('click', () => location.reload());
     });
   </script>
+  <script src="chat.js" nonce="a1b2c3"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- connect chat.js to scalermax API
- enforce 1 minute cooldown between messages
- show cooldown warning and style system messages
- add dark chat widget with purple glow to dashboard

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864945705c88327b4d3a5a18f3dc930