### PR TITLE
Enable demo login and dark purple UI

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -7,11 +7,12 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-ENjdO4Dr2bkBIFxQpeoYz1CnGdZXQ7YKj+47HCsHEB2z9vOo5dKZ7HisZV64VAN2" crossorigin="anonymous">
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet" integrity="sha512-p6N8z1lnjIYE/4ub2QzEC2lN6pGHixuJv2z7P7q+VZl+PvGhDwXMJv+0U1TpH+EOqs0c1aj3Gq38PDRYTq0c9w==" crossorigin="anonymous" referrerpolicy="no-referrer">
   <style nonce="a1b2c3">
-    body { font-family: 'Segoe UI', Tahoma, sans-serif; background-color: #f8f9fa; }
-    .sidebar-desktop { height: 100vh; position: fixed; top: 56px; left: 0; width: 240px; padding-top: 1rem; background-color: #343a40; overflow-y: auto; }
-    .sidebar-desktop a { color: #adb5bd; padding: .75rem 1.25rem; display: block; text-decoration: none; }
-    .sidebar-desktop a.active, .sidebar-desktop a:hover { color: #fff; background-color: #495057; }
+    body { font-family: 'Segoe UI', Tahoma, sans-serif; background-color: #0d0b1f; color:#e0e0e0; }
+    .sidebar-desktop { height: 100vh; position: fixed; top: 56px; left: 0; width: 240px; padding-top: 1rem; background-color: #1b1431; overflow-y: auto; }
+    .sidebar-desktop a { color: #d1c4e9; padding: .75rem 1.25rem; display: block; text-decoration: none; }
+    .sidebar-desktop a.active, .sidebar-desktop a:hover { color: #fff; background-color: #371c59; }
     main { margin-top: 56px; margin-left: 240px; padding: 1rem; }
+    .navbar-dark { background-color:#1b1431 !important; box-shadow:0 0 10px rgba(155,92,245,0.6); }
     @media (max-width: 768px) {
       .sidebar-desktop { display: none; }
       main { margin-left: 0; }
@@ -19,7 +20,8 @@
     .card-counter { display: flex; align-items: center; justify-content: space-between; padding: 1rem; color: #fff; }
     .card-counter .icon { font-size: 2rem; opacity: .7; }
     .card-counter .count { font-size: 1.75rem; font-weight: bold; }
-    .chat-card { background:#1e1e2f; box-shadow:0 0 10px 2px rgba(128,0,255,0.6); }
+    .card { background:#1d1533; border:none; color:#e0e0e0; box-shadow:0 0 10px rgba(155,92,245,0.3); }
+    .chat-card { background:#1e1e2f; box-shadow:0 0 10px 2px rgba(155,92,245,0.6); }
     #chat-container { height:300px; overflow-y:auto; padding:0.5rem; }
     .message { padding:0.25rem 0.5rem; margin-bottom:0.25rem; border-radius:4px; }
     .message-user { background:#4b0082; color:#fff; text-align:right; }
@@ -53,12 +55,24 @@
       <a href="#" class="d-block text-light px-3 py-2"><i class="fas fa-cogs me-2"></i>Settings</a>
     </div>
   </aside>
-  <main role="main">
-    <div class="d-flex justify-content-between align-items-center mb-4">
-      <h1 class="h2">Dashboard</h1>
-      <button id="refreshBtn" class="btn btn-sm btn-outline-secondary"><i class="fas fa-sync-alt"></i> Refresh</button>
-    </div>
-    <div class="row g-3 mb-4">
+  <main role="main" class="container-fluid">
+    <div class="row">
+      <div class="col-lg-4 order-lg-1 mb-4">
+        <h2>Chat Demo</h2>
+        <div class="card chat-card text-light">
+          <div id="chat-container" class="mb-2" aria-live="polite" role="log"></div>
+          <form id="chat-form" class="d-flex">
+            <input id="chat-input" type="text" class="form-control me-2" placeholder="Type a message..." aria-label="chat input" disabled>
+            <button id="send-button" class="btn btn-primary" type="submit" disabled>Send</button>
+          </form>
+        </div>
+      </div>
+      <div class="col-lg-8 order-lg-2">
+        <div class="d-flex justify-content-between align-items-center mb-4">
+          <h1 class="h2">Dashboard</h1>
+          <button id="refreshBtn" class="btn btn-sm btn-outline-secondary"><i class="fas fa-sync-alt"></i> Refresh</button>
+        </div>
+        <div class="row g-3 mb-4">
       <div class="col-sm-6 col-md-3">
         <div class="card bg-primary">
           <div class="card-counter">
@@ -140,14 +154,6 @@
         </table>
       </div>
     </div>
-    <div class="mt-4">
-      <h2>Chat Demo</h2>
-      <div class="card chat-card text-light">
-        <div id="chat-container" class="mb-2" aria-live="polite" role="log"></div>
-        <form id="chat-form" class="d-flex">
-          <input id="chat-input" type="text" class="form-control me-2" placeholder="Type a message..." aria-label="chat input" disabled>
-          <button id="send-button" class="btn btn-primary" type="submit" disabled>Send</button>
-        </form>
       </div>
     </div>
   </main>

--- a/login.html
+++ b/login.html
@@ -19,7 +19,7 @@
     })();
   </script>
   <main class="login-container">
-    <form id="loginForm" class="login-form" action="/api/login" method="POST" novalidate>
+    <form id="loginForm" class="login-form" novalidate>
       <h1>Login to ScalerMax</h1>
       <div class="form-group">
         <label for="email">Email</label>
@@ -69,27 +69,12 @@
         const submitButton = form.querySelector('button[type="submit"]');
         submitButton.disabled = true;
         submitButton.textContent = 'Logging in...';
-        fetch(form.action, {
-          method: 'POST',
-          headers: {'Content-Type': 'application/json'},
-          credentials: 'include',
-          body: JSON.stringify({email: email, password: password})
-        })
-        .then(response => {
-          if (response.ok) {
-            window.location.replace('dashboard.html');
-          } else {
-            return response.json().then(data => {
-              const message = data.message || 'Login failed. Please try again.';
-              throw new Error(message);
-            });
-          }
-        })
-        .catch(error => {
-          submitButton.disabled = false;
-          submitButton.textContent = 'Login';
-          passwordError.textContent = error.message;
-        });
+        const tokenArray = new Uint8Array(16);
+        window.crypto.getRandomValues(tokenArray);
+        const token = Array.from(tokenArray, b => ('00' + b.toString(16)).slice(-2)).join('');
+        const expires = new Date(Date.now() + 86400000).toUTCString();
+        document.cookie = `authToken=${token}; Expires=${expires}; Path=/; SameSite=Strict`;
+        window.location.replace('dashboard.html');
       });
     })();
   </script>

--- a/styles.css
+++ b/styles.css
@@ -1,15 +1,15 @@
 :root {
-  --color-bg: #f4f6f8;
-  --color-sidebar-bg: #1f2937;
-  --color-sidebar-text: #e5e7eb;
-  --color-header-bg: #ffffff;
-  --color-card-bg: #ffffff;
-  --color-primary: #3b82f6;
-  --color-secondary: #10b981;
+  --color-bg: #0d0b1f;
+  --color-sidebar-bg: #1b1431;
+  --color-sidebar-text: #d1c4e9;
+  --color-header-bg: #1b1431;
+  --color-card-bg: #1d1533;
+  --color-primary: #9b5cf5;
+  --color-secondary: #c084fc;
   --color-accent: #f59e0b;
-  --color-text: #334155;
-  --color-text-light: #6b7280;
-  --color-border: #e5e7eb;
+  --color-text: #e0e0e0;
+  --color-text-light: #b0b0b0;
+  --color-border: #36304b;
   --font-sans: 'Inter', sans-serif;
   --transition-fast: 0.2s ease-in-out;
   --transition-medium: 0.4s ease-in-out;
@@ -278,4 +278,78 @@ button:focus,
 }
 @keyframes spinLoader {
   to { transform: rotate(360deg); }
+}
+
+/* Login form styling */
+.login-container {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--color-bg);
+  color: var(--color-text);
+}
+
+.login-form {
+  background-color: var(--color-card-bg);
+  padding: 2rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 0 20px rgba(155, 92, 245, 0.6);
+  width: 100%;
+  max-width: 22rem;
+}
+
+.login-form h1 {
+  margin-bottom: 1rem;
+  text-align: center;
+  color: var(--color-primary);
+}
+
+.form-group {
+  margin-bottom: 1rem;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 0.25rem;
+  color: var(--color-text-light);
+}
+
+.form-group input {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: 0.375rem;
+  background-color: #22183c;
+  color: var(--color-text);
+}
+
+.error-message {
+  color: #f87171;
+  font-size: 0.875rem;
+  min-height: 1rem;
+  display: block;
+}
+
+.helper-text {
+  margin-top: 0.5rem;
+  font-size: 0.875rem;
+  text-align: center;
+  color: var(--color-text-light);
+}
+
+.btn {
+  display: inline-block;
+  width: 100%;
+  padding: 0.5rem 1rem;
+  background-color: var(--color-primary);
+  color: #fff;
+  font-size: 0.875rem;
+  border-radius: 0.375rem;
+  transition: box-shadow var(--transition-fast), background var(--transition-fast);
+}
+
+.btn:hover {
+  background-color: var(--color-primary);
+  box-shadow: 0 0 10px var(--color-primary);
 }


### PR DESCRIPTION
## Summary
- allow any credentials to sign in
- switch to dark purple color theme
- restyle login page with glow
- show chat on left side of dashboard

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_686496304de883279b02954be861022b