### PR TITLE
Add API key buttons to dashboard

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -27,6 +27,12 @@
     .message-user { background:#4b0082; color:#fff; text-align:right; }
     .message-ai { background:#333; color:#fff; }
     .message-system { background:#222; color:#e0e0e0; font-style:italic; }
+    .api-btn {
+      background: linear-gradient(45deg, #22c55e, #8b5cf6);
+      color: #fff;
+      border: none;
+    }
+    .api-btn:hover { opacity: 0.9; }
   </style>
 </head>
 <body>
@@ -70,8 +76,13 @@
       <div class="col-lg-8 order-lg-2">
         <div class="d-flex justify-content-between align-items-center mb-4">
           <h1 class="h2">Dashboard</h1>
-          <button id="refreshBtn" class="btn btn-sm btn-outline-secondary"><i class="fas fa-sync-alt"></i> Refresh</button>
+          <div>
+            <button id="refreshBtn" class="btn btn-sm btn-outline-secondary me-2"><i class="fas fa-sync-alt"></i> Refresh</button>
+            <button id="openrouterBtn" class="btn btn-sm api-btn me-2">Add OpenRouter API Key</button>
+            <button id="straicoBtn" class="btn btn-sm api-btn">Add Straico API Key</button>
+          </div>
         </div>
+        <div id="apikeyMessage" class="mb-4" style="color:#fff; display:none;"></div>
         <div class="row g-3 mb-4">
       <div class="col-sm-6 col-md-3">
         <div class="card bg-primary">
@@ -216,6 +227,13 @@
         tbody.appendChild(tr);
       });
       document.getElementById('refreshBtn').addEventListener('click', () => location.reload());
+      const msgEl = document.getElementById('apikeyMessage');
+      function showDemoMessage() {
+        msgEl.textContent = 'This is a demo site only.';
+        msgEl.style.display = 'block';
+      }
+      document.getElementById('openrouterBtn').addEventListener('click', showDemoMessage);
+      document.getElementById('straicoBtn').addEventListener('click', showDemoMessage);
     });
   </script>
   <script src="chat.js" nonce="a1b2c3"></script>


### PR DESCRIPTION
## Summary
- add OpenRouter and Straico API key buttons
- show demo-only message when buttons clicked

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68649ec9b6c08327b8f67b9240fb061f