### PR TITLE
Add model selection logging

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -112,9 +112,20 @@ function logError(error, requestId = null) {
   console.error(safeStringify(entry))
 }
 
+function logModelSelection(intent, model) {
+  const entry = {
+    timestamp: new Date().toISOString(),
+    level: 'info',
+    message: 'Model selection',
+    data: { intent, model }
+  }
+  console.log(safeStringify(entry))
+}
+
 module.exports = {
   logRequest,
   logResponse,
   logError,
+  logModelSelection,
   safeStringify
 }

--- a/scalermax-api.js
+++ b/scalermax-api.js
@@ -1,4 +1,4 @@
-const { logRequest, logResponse, logError } = require('./logger');
+const { logRequest, logResponse, logError, logModelSelection } = require('./logger');
 const { sendRequest } = require('./openrouterclient');
 
 const CORS_HEADERS = {
@@ -115,6 +115,7 @@ exports.handler = async function(event, context) {
   }
   const intent = classifyPrompt(prompt);
   const route = ROUTER_CONFIG[intent] || ROUTER_CONFIG.planning;
+  logModelSelection(intent, route.model);
   const messages = [
     { role: 'system', content: `You are a helpful assistant specialized in ${intent} tasks.` },
     { role: 'user', content: prompt }


### PR DESCRIPTION
## Summary
- log chosen model in server logs
- expose new `logModelSelection` util

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6864a175718c83278468eeea0683a489