### PR TITLE
Add placeholder icons and purple theme

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -7,15 +7,15 @@
   <link href="https://fonts.googleapis.com/css?family=Inter:400,500,600&display=swap" rel="stylesheet">
   <style>
     * {box-sizing:border-box;margin:0;padding:0;}
-    body {background:#f4f6f8;color:#333;font-family:'Inter',sans-serif;line-height:1.6;}
+    body {background:#0d0b1f;color:#e0e0e0;font-family:'Inter',sans-serif;line-height:1.6;}
     .container {max-width:1200px;margin:0 auto;padding:20px;}
     header {display:flex;justify-content:space-between;align-items:center;margin-bottom:20px;}
-    header h1 {font-size:1.8rem;color:#444;}
+    header h1 {font-size:1.8rem;color:#e0e0e0;}
     .stats-cards {display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:20px;margin-bottom:40px;}
-    .card {background:#fff;padding:20px;border-radius:8px;box-shadow:0 2px 4px rgba(0,0,0,0.1);opacity:0;transform:translateY(20px);animation:fadeInUp 0.6s forwards;transition:transform .3s;}
+    .card {background:#1d1533;padding:20px;border-radius:8px;box-shadow:0 0 10px rgba(155,92,245,0.4);color:#e0e0e0;opacity:0;transform:translateY(20px);animation:fadeInUp 0.6s forwards;transition:transform .3s;}
     .card:hover {transform:scale(1.05);}
-    .card h3 {font-size:1rem;color:#666;margin-bottom:10px;}
-    .card p.value {font-size:1.6rem;color:#222;font-weight:600;}
+    .card h3 {font-size:1rem;color:#c084fc;margin-bottom:10px;}
+    .card p.value {font-size:1.6rem;color:#fff;font-weight:600;}
     .card:nth-child(1){animation-delay:0.1s;}
     .card:nth-child(2){animation-delay:0.2s;}
     .card:nth-child(3){animation-delay:0.3s;}
@@ -24,10 +24,11 @@
     .card:nth-child(6){animation-delay:0.6s;}
     @keyframes fadeInUp {to {opacity:1;transform:translateY(0);}}
     .charts {display:grid;grid-template-columns:1fr 1fr;gap:40px;margin-bottom:40px;}
-    .chart-container {background:#fff;padding:20px;border-radius:8px;box-shadow:0 2px 4px rgba(0,0,0,0.1);height:300px;position:relative;}
+    .chart-container {background:#1d1533;padding:20px;border-radius:8px;box-shadow:0 0 10px rgba(155,92,245,0.4);height:300px;position:relative;}
     .chart-container canvas {width:100%;height:100%;}
     figure {margin:0;height:100%;}
-    figure figcaption {text-align:center;font-size:0.9rem;color:#666;margin-top:8px;}
+    figure figcaption {text-align:center;font-size:0.9rem;color:#e0e0e0;margin-top:8px;}
+    .card img.icon-img {width:40px;margin-bottom:10px;filter:drop-shadow(0 0 6px rgba(155,92,245,0.8));}
     @media(max-width:768px){.charts {grid-template-columns:1fr;}}
   </style>
 </head>
@@ -39,26 +40,32 @@
     </header>
     <section class="stats-cards">
       <div class="card">
+        <img src="intents_icon.png" alt="Intents" class="icon-img">
         <h3>Total Intents Classified</h3>
         <p id="totalIntents" class="value">0</p>
       </div>
       <div class="card">
+        <img src="requests_icon.png" alt="Requests" class="icon-img">
         <h3>Requests/min</h3>
         <p id="requestsPerMinute" class="value">0</p>
       </div>
       <div class="card">
+        <img src="latency_icon.png" alt="Latency" class="icon-img">
         <h3>Avg Response Time</h3>
         <p id="avgResponseTime" class="value">0ms</p>
       </div>
       <div class="card">
+        <img src="accuracy_icon.png" alt="Accuracy" class="icon-img">
         <h3>Routing Accuracy</h3>
         <p id="routingAccuracy" class="value">0%</p>
       </div>
       <div class="card">
+        <img src="cpu_icon.png" alt="CPU" class="icon-img">
         <h3>CPU Usage</h3>
         <p id="cpuUsage" class="value">0%</p>
       </div>
       <div class="card">
+        <img src="memory_icon.png" alt="Memory" class="icon-img">
         <h3>Memory Usage</h3>
         <p id="memoryUsage" class="value">0%</p>
       </div>
@@ -153,19 +160,19 @@
         const rpmCtx = document.getElementById('rpmChart').getContext('2d');
         const rpmChart = new Chart(rpmCtx,{
           type:'line',
-          data:{labels:rpmLabels,datasets:[{label:'Req/min',data:rpmData,borderColor:'#4CAF50',backgroundColor:'rgba(76,175,80,0.2)',fill:true,tension:0.4}]},
+          data:{labels:rpmLabels,datasets:[{label:'Req/min',data:rpmData,borderColor:'#9b5cf5',backgroundColor:'rgba(155,92,245,0.2)',fill:true,tension:0.4}]},
           options:{responsive:true,maintainAspectRatio:false,animation:{duration:1000},scales:{x:{display:true},y:{beginAtZero:true}}}
         });
         const distCtx = document.getElementById('distributionChart').getContext('2d');
         const distChart = new Chart(distCtx,{
           type:'pie',
-          data:{labels:models,datasets:[{data:randomDistribution(models.length),backgroundColor:['#2196F3','#FF9800','#9C27B0','#F44336']}]},
+          data:{labels:models,datasets:[{data:randomDistribution(models.length),backgroundColor:['#8a2be2','#a855f7','#6d28d9','#9333ea']}]},
           options:{responsive:true,maintainAspectRatio:false,animation:{duration:1000}}
         });
         const barCtx = document.getElementById('responseTimeChart').getContext('2d');
         const barChart = new Chart(barCtx,{
           type:'bar',
-          data:{labels:models,datasets:[{label:'Avg Response (ms)',data:models.map(()=>adminRandomInt(100,600)),backgroundColor:['#3F51B5','#03A9F4','#8BC34A','#FFC107']}]},
+          data:{labels:models,datasets:[{label:'Avg Response (ms)',data:models.map(()=>adminRandomInt(100,600)),backgroundColor:['#7c3aed','#6d28d9','#8b5cf6','#c084fc']}]},
           options:{responsive:true,maintainAspectRatio:false,animation:{duration:1000},scales:{y:{beginAtZero:true}}}
         });
         setInterval(function(){

--- a/dashboard.html
+++ b/dashboard.html
@@ -19,6 +19,7 @@
     }
     .card-counter { display: flex; align-items: center; justify-content: space-between; padding: 1rem; color: #fff; }
     .card-counter .icon { font-size: 2rem; opacity: .7; }
+    .card-counter img.icon-img { width:32px; height:32px; opacity:.7; }
     .card-counter .count { font-size: 1.75rem; font-weight: bold; }
     .card { background:#1d1533; border:none; color:#e0e0e0; box-shadow:0 0 10px rgba(155,92,245,0.3); }
     .chat-card { background:#1e1e2f; box-shadow:0 0 10px 2px rgba(155,92,245,0.6); }
@@ -44,10 +45,10 @@
     </div>
   </nav>
   <aside class="sidebar-desktop">
-    <a href="#" class="active"><i class="fas fa-tachometer-alt me-2"></i>Dashboard</a>
-    <a href="#"><i class="fas fa-brain me-2"></i>Intents</a>
-    <a href="#"><i class="fas fa-route me-2"></i>Routes</a>
-    <a href="#"><i class="fas fa-cogs me-2"></i>Settings</a>
+    <a href="#" class="active"><img src="dashboard_icon.png" alt="Dashboard" class="icon-img me-2">Dashboard</a>
+    <a href="#"><img src="intents_icon.png" alt="Intents" class="icon-img me-2">Intents</a>
+    <a href="#"><img src="routes_icon.png" alt="Routes" class="icon-img me-2">Routes</a>
+    <a href="#"><img src="settings_icon.png" alt="Settings" class="icon-img me-2">Settings</a>
   </aside>
   <aside class="offcanvas offcanvas-start d-md-none" tabindex="-1" id="sidebarOffcanvas" aria-labelledby="sidebarOffcanvasLabel">
     <div class="offcanvas-header bg-dark text-white">
@@ -55,10 +56,10 @@
       <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
     </div>
     <div class="offcanvas-body p-0 bg-dark">
-      <a href="#" class="d-block text-light px-3 py-2 active"><i class="fas fa-tachometer-alt me-2"></i>Dashboard</a>
-      <a href="#" class="d-block text-light px-3 py-2"><i class="fas fa-brain me-2"></i>Intents</a>
-      <a href="#" class="d-block text-light px-3 py-2"><i class="fas fa-route me-2"></i>Routes</a>
-      <a href="#" class="d-block text-light px-3 py-2"><i class="fas fa-cogs me-2"></i>Settings</a>
+      <a href="#" class="d-block text-light px-3 py-2 active"><img src="dashboard_icon.png" alt="Dashboard" class="icon-img me-2">Dashboard</a>
+      <a href="#" class="d-block text-light px-3 py-2"><img src="intents_icon.png" alt="Intents" class="icon-img me-2">Intents</a>
+      <a href="#" class="d-block text-light px-3 py-2"><img src="routes_icon.png" alt="Routes" class="icon-img me-2">Routes</a>
+      <a href="#" class="d-block text-light px-3 py-2"><img src="settings_icon.png" alt="Settings" class="icon-img me-2">Settings</a>
     </div>
   </aside>
   <main role="main" class="container-fluid">
@@ -77,7 +78,7 @@
         <div class="d-flex justify-content-between align-items-center mb-4">
           <h1 class="h2">Dashboard</h1>
           <div>
-            <button id="refreshBtn" class="btn btn-sm btn-outline-secondary me-2"><i class="fas fa-sync-alt"></i> Refresh</button>
+            <button id="refreshBtn" class="btn btn-sm btn-outline-secondary me-2"><img src="refresh_icon.png" alt="Refresh" class="icon-img me-1">Refresh</button>
             <button id="openrouterBtn" class="btn btn-sm api-btn me-2">Add OpenRouter API Key</button>
             <button id="straicoBtn" class="btn btn-sm api-btn">Add Straico API Key</button>
           </div>
@@ -91,7 +92,7 @@
               <div class="card-title">Total Requests</div>
               <div class="count"><span class="counter" data-target="12345">0</span></div>
             </div>
-            <div class="icon"><i class="fas fa-chart-line"></i></div>
+            <div class="icon"><img src="requests_icon.png" alt="Total requests" class="icon-img"></div>
           </div>
         </div>
       </div>
@@ -102,7 +103,7 @@
               <div class="card-title">Active Intents</div>
               <div class="count"><span class="counter" data-target="456">0</span></div>
             </div>
-            <div class="icon"><i class="fas fa-brain"></i></div>
+            <div class="icon"><img src="intents_icon.png" alt="Active intents" class="icon-img"></div>
           </div>
         </div>
       </div>
@@ -113,7 +114,7 @@
               <div class="card-title">Error Rate</div>
               <div class="count"><span class="counter" data-target="2.5" data-decimals="1">0</span><span>%</span></div>
             </div>
-            <div class="icon"><i class="fas fa-exclamation-triangle"></i></div>
+            <div class="icon"><img src="error_icon.png" alt="Error rate" class="icon-img"></div>
           </div>
         </div>
       </div>
@@ -124,7 +125,7 @@
               <div class="card-title">Avg Latency</div>
               <div class="count"><span class="counter" data-target="120">0</span><span>ms</span></div>
             </div>
-            <div class="icon"><i class="fas fa-stopwatch"></i></div>
+            <div class="icon"><img src="latency_icon.png" alt="Average latency" class="icon-img"></div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- update dashboard with PNG placeholder icons
- switch admin dashboard to dark purple design
- adjust chart colors for new theme

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864a5969e048327aad03d412192c27b