### PR TITLE
Add HARDCODED_API_KEY fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ ScalerMax is a demo-ready AI Intent Server deployed on Netlify. It classifies us
 
 ## Configuration
 
-- By default, `openrouterClient.js` uses a **hardcoded** `OPENROUTER_API_KEY` for rapid demo.
-- **Optional**: To use your own key, set an environment variable in Netlify:
+- `openrouterClient.js` includes a `HARDCODED_API_KEY` constant which is empty by default. You can populate this value if you want the demo to run without environment variables.
+- The recommended approach is to set an environment variable:
   ```
   OPENROUTER_API_KEY=your_openrouter_key
   ```
@@ -141,7 +141,7 @@ Response:
 - **netlify/functions/modelSelector.js**  
   Chooses execution model based on intent.  
 - **netlify/functions/openrouterClient.js**  
-  Sends requests to OpenRouter using hardcoded key.  
+  Sends requests to OpenRouter using the API key from environment variables or `HARDCODED_API_KEY`.
 - **netlify/functions/config.js**  
   Loads and validates environment-driven configuration.  
 - **netlify/functions/logger.js**  

--- a/openrouterclient.js
+++ b/openrouterclient.js
@@ -4,8 +4,13 @@ const DEFAULT_TIMEOUT_MS = process.env.OPENROUTER_TIMEOUT_MS
   : 10000;
 const DEFAULT_RETRIES = 3;
 
+// For demo purposes a hardcoded API key can be placed below.
+// Leave as an empty string to rely on the OPENROUTER_API_KEY environment variable.
+const HARDCODED_API_KEY = '';
+
 async function sendRequest(model, prompt, options = {}) {
-  const apiKey = options.apiKey || process.env.OPENROUTER_API_KEY;
+  const apiKey =
+    options.apiKey || process.env.OPENROUTER_API_KEY || HARDCODED_API_KEY;
   const url =
     options.url ||
     process.env.OPENROUTER_URL ||


### PR DESCRIPTION
## Summary
- allow optional hardcoded OpenRouter API key in `openrouterclient.js`
- document new `HARDCODED_API_KEY` option in README

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864a756c0cc8327a79562e7c4bca40a