### PR TITLE
Create Netlify function wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,9 @@ ScalerMax is a demo-ready AI Intent Server deployed on Netlify. It classifies us
 
 - **Static Files** at project root:
   - `admin.html`, `dashboard.html`, `styles.css`, `dashboard.js`, `glow.js`, `utils.js`, `chartIntegration.js`, `sidebar.js`
-- **Serverless Functions** under `netlify/functions/`:
-  - `scalermax-api.js` (entrypoint)
-  - `modelClassifier.js`
-  - `modelSelector.js`
-  - `openrouterClient.js`
-  - `config.js`
-  - `logger.js`
-  - `errorHandler.js`
+- **Serverless Functions**:
+  - `netlify/functions/scalermax-api.js` (wrapper entrypoint)
+  - Supporting modules (`scalermax-api.js`, `modelClassifier.js`, `modelSelector.js`, `openrouterClient.js`, `config.js`, `logger.js`, `errorHandler.js`)
 
 ---
 

--- a/netlify/functions/scalermax-api.js
+++ b/netlify/functions/scalermax-api.js
@@ -1,0 +1,2 @@
+const { handler } = require('../../scalermax-api');
+exports.handler = handler;


### PR DESCRIPTION
## Summary
- add `netlify/functions` directory with wrapper for `scalermax-api`
- update README architecture section to mention wrapper entrypoint

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864afd4190c83279c4ee32b4d91f7cb