### PR TITLE
Fix eslint-config-prettier version for Netlify

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@typescript-eslint/eslint-plugin": "^6.6.0",
     "eslint": "^8.44.0",
     "eslint-plugin-react": "^7.33.2",
-    "eslint-config-prettier": "^9.2.0",
+    "eslint-config-prettier": "^9.0.0",
     "prettier": "^3.8.0",
     "vitest": "^0.34.0"
   },


### PR DESCRIPTION
## Summary
- downgrade `eslint-config-prettier` to a valid release so Netlify can install dependencies

## Testing
- `npm run test` *(fails: vitest not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864b10980988327af1f1f4dff777e25