### PR TITLE
Fix Prettier version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "eslint": "^8.44.0",
     "eslint-plugin-react": "^7.33.2",
     "eslint-config-prettier": "^9.0.0",
-    "prettier": "^3.8.0",
+    "prettier": "^3.2.5",
     "vitest": "^0.34.0"
   },
   "engines": {


### PR DESCRIPTION
## Summary
- pin Prettier to ^3.2.5 to avoid missing version errors

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864b21680548327b47f01a0fb5d2dbe