### PR TITLE
Fix CSS/JS loading by removing forced redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -29,7 +29,6 @@
   from = "/*"
   to = "/index.html"
   status = 200
-  force = true
 
 [[headers]]
   for = "/.netlify/functions/*"


### PR DESCRIPTION
## Summary
- ensure static CSS/JS files aren't redirected by removing the `force` flag in `netlify.toml`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68655d01c1448327a4026222bd51ed5a