### PR TITLE
Improve dashboard UI

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -9,11 +9,11 @@
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet" integrity="sha512-p6N8z1lnjIYE/4ub2QzEC2lN6pGHixuJv2z7P7q+VZl+PvGhDwXMJv+0U1TpH+EOqs0c1aj3Gq38PDRYTq0c9w==" crossorigin="anonymous" referrerpolicy="no-referrer">
   <style nonce="a1b2c3">
     body { font-family: 'Segoe UI', Tahoma, sans-serif; background-color: #0d0b1f; color:#e0e0e0; }
-    .sidebar-desktop { height: 100vh; position: fixed; top: 56px; left: 0; width: 240px; padding-top: 1rem; background-color: #1b1431; overflow-y: auto; }
+    .sidebar-desktop { height: 100vh; position: fixed; top: 0; left: 0; width: 240px; padding-top: 1rem; background-color: #1b1431; overflow-y: auto; }
     .sidebar-desktop a { color: #d1c4e9; padding: .75rem 1.25rem; display: block; text-decoration: none; }
     .sidebar-desktop a.active, .sidebar-desktop a:hover { color: #fff; background-color: #371c59; }
-    main { margin-top: 56px; margin-left: 240px; padding: 1rem; }
-    .navbar-dark { background-color:#1b1431 !important; box-shadow:0 0 10px rgba(155,92,245,0.6); }
+    .sidebar-logo { font-size: 1.5rem; color: #fff; font-weight: bold; }
+    main { margin-top: 0; margin-left: 240px; padding: 1rem; }
     @media (max-width: 768px) {
       .sidebar-desktop { display: none; }
       main { margin-left: 0; }
@@ -32,35 +32,27 @@
       background: linear-gradient(45deg, #22c55e, #8b5cf6);
       color: #fff;
       border: none;
+      padding: 0.75rem 1.5rem;
+      font-size: 1.25rem;
     }
+    .send-btn {
+      background: linear-gradient(45deg, #9b5cf5, #22c55e);
+      color: #fff;
+      border: none;
+    }
+    .send-btn:hover { opacity: 0.9; }
     .api-btn:hover { opacity: 0.9; }
+    .connect-box { background:#1e1e2f; box-shadow:0 0 10px 2px rgba(155,92,245,0.6); }
   </style>
 </head>
 <body>
-  <nav class="navbar navbar-dark bg-dark fixed-top">
-    <div class="container-fluid">
-      <button class="btn btn-dark d-md-none me-2" type="button" data-bs-toggle="offcanvas" data-bs-target="#sidebarOffcanvas" aria-controls="sidebarOffcanvas"><i class="fas fa-bars"></i></button>
-      <a class="navbar-brand" href="#">ScalerMax Admin</a>
-      <span class="navbar-text text-light">v1.0.0</span>
-    </div>
-  </nav>
+
   <aside class="sidebar-desktop">
+    <div class="text-center mb-3 sidebar-logo">ScalerMax</div>
     <a href="#" class="active">Dashboard</a>
     <a href="#">Intents</a>
     <a href="#">Routes</a>
     <a href="#">Settings</a>
-  </aside>
-  <aside class="offcanvas offcanvas-start d-md-none" tabindex="-1" id="sidebarOffcanvas" aria-labelledby="sidebarOffcanvasLabel">
-    <div class="offcanvas-header bg-dark text-white">
-      <h5 class="offcanvas-title" id="sidebarOffcanvasLabel">ScalerMax Admin</h5>
-      <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close"></button>
-    </div>
-    <div class="offcanvas-body p-0 bg-dark">
-      <a href="#" class="d-block text-light px-3 py-2 active">Dashboard</a>
-      <a href="#" class="d-block text-light px-3 py-2">Intents</a>
-      <a href="#" class="d-block text-light px-3 py-2">Routes</a>
-      <a href="#" class="d-block text-light px-3 py-2">Settings</a>
-    </div>
   </aside>
   <main role="main" class="container-fluid">
     <div class="row">
@@ -69,18 +61,21 @@
         <div class="card chat-card text-light">
           <div id="chat-container" class="mb-2" aria-live="polite" role="log"></div>
           <form id="chat-form" class="d-flex">
-            <input id="chat-input" type="text" class="form-control me-2" placeholder="Type a message..." aria-label="chat input" disabled>
-            <button id="send-button" class="btn btn-primary" type="submit" disabled>Send</button>
+            <input id="chat-input" type="text" class="form-control form-control-lg me-2" placeholder="Type a message..." aria-label="chat input" disabled>
+            <button id="send-button" class="btn send-btn btn-lg" type="submit" disabled>Send</button>
           </form>
         </div>
       </div>
       <div class="col-lg-8 order-lg-2">
+        <div class="connect-box card p-3 mb-4 text-center">
+          <p class="mb-3">Connect your accounts to get started.</p>
+          <button id="openrouterBtn" class="btn api-btn btn-lg me-2">OpenRouter</button>
+          <button id="straicoBtn" class="btn api-btn btn-lg">Straico</button>
+        </div>
         <div class="d-flex justify-content-between align-items-center mb-4">
-          <h1 class="h2">Dashboard</h1>
+          <h1 class="h2 m-0">Dashboard</h1>
           <div>
-            <button id="refreshBtn" class="btn btn-sm btn-outline-secondary me-2">Refresh</button>
-            <button id="openrouterBtn" class="btn btn-sm api-btn me-2">Add OpenRouter API Key</button>
-            <button id="straicoBtn" class="btn btn-sm api-btn">Add Straico API Key</button>
+            <button id="refreshBtn" class="btn btn-sm btn-outline-secondary">Refresh</button>
           </div>
         </div>
         <div id="apikeyMessage" class="mb-4" style="color:#fff; display:none;"></div>
@@ -124,6 +119,28 @@
             <div>
               <div class="card-title">Avg Latency</div>
               <div class="count"><span class="counter" data-target="120">0</span><span>ms</span></div>
+            </div>
+            <div class="icon"></div>
+          </div>
+        </div>
+      </div>
+      <div class="col-sm-6 col-md-3">
+        <div class="card bg-info">
+          <div class="card-counter">
+            <div>
+              <div class="card-title">Placeholder A</div>
+              <div class="count"><span class="counter" data-target="0">0</span></div>
+            </div>
+            <div class="icon"></div>
+          </div>
+        </div>
+      </div>
+      <div class="col-sm-6 col-md-3">
+        <div class="card bg-secondary">
+          <div class="card-counter">
+            <div>
+              <div class="card-title">Placeholder B</div>
+              <div class="count"><span class="counter" data-target="0">0</span></div>
             </div>
             <div class="icon"></div>
           </div>
@@ -242,7 +259,7 @@
       document.getElementById('refreshBtn').addEventListener('click', () => location.reload());
       const msgEl = document.getElementById('apikeyMessage');
       function showDemoMessage() {
-        msgEl.textContent = 'This is a demo site only.';
+        msgEl.textContent = 'Demo Only';
         msgEl.style.display = 'block';
       }
       document.getElementById('openrouterBtn').addEventListener('click', showDemoMessage);


### PR DESCRIPTION
## Summary
- remove top nav and start sidebar at top
- add ScalerMax branding to sidebar
- enlarge chat input and stylize send button
- add connection box with big provider buttons
- insert placeholder metrics
- show 'Demo Only' message when buttons clicked

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68656ca405d88327bb93a44207459346