### PR TITLE
Fix logo glow & add privacy navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,139 +1,248 @@
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>ScalerMax FE - AI Intent Demo</title>
-  <meta name="description" content="ScalerMax FE: A privacy-first AI Intent Analysis Frontend Demo.">
-  <meta name="theme-color" content="#0a2540">
-  <meta property="og:title" content="ScalerMax FE - AI Intent Demo">
-  <meta property="og:description" content="ScalerMax FE: A privacy-first AI Intent Analysis Frontend Demo">
-  <meta property="og:url" content="https://scalermax-fe.netlify.app/">
-  <meta property="og:type" content="website">
-  <meta name="twitter:card" content="summary_large_image">
-  <link rel="preconnect" href="https://fonts.gstatic.com">
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="styles.css">
-  <script defer src="headernav.js"></script>
-  <script defer src="animationsmanager.js"></script>
-  <script defer src="glow.js"></script>
-</head>
-<body>
-  <header class="site-header" data-animation="fade-up" data-animation-trigger="timed" data-animation-delay="100">
-    <div class="container">
-      <a href="index.html" class="logo">ScalerMax</a>
-      <button class="nav-toggle" data-nav-toggle aria-label="Open navigation" aria-expanded="false" aria-controls="primary-navigation">
-        <span class="hamburger"></span>
-      </button>
-      <nav id="primary-navigation" data-nav-menu class="site-nav" aria-label="Primary navigation">
-        <ul>
-          <li><a href="index.html">Home</a></li>
-          <li><a href="login.html" id="nav-login">Login</a></li>
-          <li data-dashboard-link style="display:none;"><a href="dashboard.html">Dashboard</a></li>
-          <li><a href="privacy.html">Privacy</a></li>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>ScalerMax FE - AI Intent Demo</title>
+    <meta
+      name="description"
+      content="ScalerMax FE: A privacy-first AI Intent Analysis Frontend Demo."
+    />
+    <meta name="theme-color" content="#0a2540" />
+    <meta property="og:title" content="ScalerMax FE - AI Intent Demo" />
+    <meta
+      property="og:description"
+      content="ScalerMax FE: A privacy-first AI Intent Analysis Frontend Demo"
+    />
+    <meta property="og:url" content="https://scalermax-fe.netlify.app/" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+    <script defer src="headernav.js"></script>
+    <script defer src="animationsmanager.js"></script>
+    <script defer src="glow.js"></script>
+  </head>
+  <body>
+    <header
+      class="site-header"
+      data-animation="fade-up"
+      data-animation-trigger="timed"
+      data-animation-delay="100"
+    >
+      <div class="container">
+        <a href="index.html" class="logo">ScalerMax</a>
+        <button
+          class="nav-toggle"
+          data-nav-toggle
+          aria-label="Open navigation"
+          aria-expanded="false"
+          aria-controls="primary-navigation"
+        >
+          <span class="hamburger"></span>
+        </button>
+        <nav
+          id="primary-navigation"
+          data-nav-menu
+          class="site-nav"
+          aria-label="Primary navigation"
+        >
+          <ul>
+            <li><a href="index.html">Home</a></li>
+            <li><a href="login.html" id="nav-login">Login</a></li>
+            <li data-dashboard-link style="display: none">
+              <a href="dashboard.html">Dashboard</a>
+            </li>
+            <li><a href="privacy.html">Privacy</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+    <main>
+      <section
+        class="hero"
+        data-animation="fade-up"
+        data-animation-trigger="timed"
+        data-animation-delay="200"
+      >
+        <div class="container hero-content">
+          <h1 class="hero-title">Welcome to ScalerMax</h1>
+          <p class="hero-subtitle">
+            AI-Powered Intent Analysis, Privacy-First &amp; Easy to Use.
+          </p>
+          <a href="login.html" class="btn btn-primary" id="hero-start"
+            >Get Started</a
+          >
+          <img
+            class="hero-image"
+            src="/images/hero.jpg"
+            alt="placeholder hero"
+          />
+        </div>
+        <ul class="animated-shapes" aria-hidden="true">
+          <li></li>
+          <li></li>
+          <li></li>
+          <li></li>
+          <li></li>
+          <li></li>
+          <li></li>
+          <li></li>
+          <li></li>
+          <li></li>
         </ul>
-      </nav>
-    </div>
-  </header>
-  <main>
-    <section class="hero" data-animation="fade-up" data-animation-trigger="timed" data-animation-delay="200">
-      <div class="container hero-content">
-        <h1 class="hero-title">Welcome to ScalerMax</h1>
-        <p class="hero-subtitle">AI-Powered Intent Analysis, Privacy-First &amp; Easy to Use.</p>
-        <a href="login.html" class="btn btn-primary" id="hero-start">Get Started</a>
-        <img class="hero-image" src="/images/hero.jpg" alt="placeholder hero" />
-      </div>
-      <ul class="animated-shapes" aria-hidden="true">
-        <li></li><li></li><li></li><li></li><li></li>
-        <li></li><li></li><li></li><li></li><li></li>
-      </ul>
-    </section>
-    <section class="marketing" data-animation="fade-up">
-      <div class="container">
-        <h2>Discover the Future of AI Automation</h2>
-        <p>ScalerMax continuously benchmarks the world's best AI models so you don't have to. Our system automatically selects the optimal model for your task, delivering state-of-the-art results with zero hassle.</p>
-        <img src="/images/marketing1.jpg" alt="abstract ai graphic">
-      </div>
-    </section>
-    <section class="marketing" data-animation="fade-up" data-animation-delay="200">
-      <div class="container">
-        <h2>Always the Best Model</h2>
-        <p>Our smart selector analyzes your requirements and instantly routes requests to the highest performing model available, ensuring quality and efficiency on every call.</p>
-        <img src="/images/marketing2.jpg" alt="model selection illustration">
-      </div>
-    </section>
-    <section class="marketing" data-animation="fade-up" data-animation-delay="300">
-      <div class="container">
-        <h2>Meet ScalerMax the Smart AI Agent</h2>
-        <p>Embed intelligent automation into your apps with a single API. ScalerMax brings the power of modern language models to every tool in your workflow.</p>
-        <div class="feature-grid">
-          <div class="feature-item">
-            <img src="/images/icon1.png" alt="placeholder icon">
-            <h3>Easy Integration</h3>
-            <p>Drop our endpoint into any service and start sending prompts immediately.</p>
-          </div>
-          <div class="feature-item">
-            <img src="/images/icon2.png" alt="placeholder icon">
-            <h3>Automated Routing</h3>
-            <p>ScalerMax dynamically selects the best model for you behind the scenes.</p>
-          </div>
-          <div class="feature-item">
-            <img src="/images/icon3.png" alt="placeholder icon">
-            <h3>Insightful Metrics</h3>
-            <p>Monitor usage and quality with our glowing, responsive dashboard.</p>
+      </section>
+      <section class="marketing" data-animation="fade-up">
+        <div class="container">
+          <h2>Discover the Future of AI Automation</h2>
+          <p>
+            ScalerMax continuously benchmarks the world's best AI models so you
+            don't have to. Our system automatically selects the optimal model
+            for your task, delivering state-of-the-art results with zero hassle.
+          </p>
+          <img src="/images/marketing1.jpg" alt="abstract ai graphic" />
+        </div>
+      </section>
+      <section
+        class="marketing"
+        data-animation="fade-up"
+        data-animation-delay="200"
+      >
+        <div class="container">
+          <h2>Always the Best Model</h2>
+          <p>
+            Our smart selector analyzes your requirements and instantly routes
+            requests to the highest performing model available, ensuring quality
+            and efficiency on every call.
+          </p>
+          <img
+            src="/images/marketing2.jpg"
+            alt="model selection illustration"
+          />
+        </div>
+      </section>
+      <section
+        class="marketing"
+        data-animation="fade-up"
+        data-animation-delay="300"
+      >
+        <div class="container">
+          <h2>Meet ScalerMax the Smart AI Agent</h2>
+          <p>
+            Embed intelligent automation into your apps with a single API.
+            ScalerMax brings the power of modern language models to every tool
+            in your workflow.
+          </p>
+          <div class="feature-grid">
+            <div class="feature-item">
+              <img src="/images/icon1.png" alt="placeholder icon" />
+              <h3>Easy Integration</h3>
+              <p>
+                Drop our endpoint into any service and start sending prompts
+                immediately.
+              </p>
+            </div>
+            <div class="feature-item">
+              <img src="/images/icon2.png" alt="placeholder icon" />
+              <h3>Automated Routing</h3>
+              <p>
+                ScalerMax dynamically selects the best model for you behind the
+                scenes.
+              </p>
+            </div>
+            <div class="feature-item">
+              <img src="/images/icon3.png" alt="placeholder icon" />
+              <h3>Insightful Metrics</h3>
+              <p>
+                Monitor usage and quality with our glowing, responsive
+                dashboard.
+              </p>
+            </div>
           </div>
         </div>
-      </div>
-    </section>
-    <section class="marketing" data-animation="fade-up" data-animation-delay="350">
-      <div class="container">
-        <h2>Image Gallery</h2>
-        <p>Replace these placeholders with stunning AI images to showcase your creativity.</p>
-        <div class="gallery-grid">
-          <img src="/images/gallery1.jpg" alt="placeholder image 1">
-          <img src="/images/gallery2.jpg" alt="placeholder image 2">
-          <img src="/images/gallery3.jpg" alt="placeholder image 3">
-          <img src="/images/gallery4.jpg" alt="placeholder image 4">
+      </section>
+      <section
+        class="marketing"
+        data-animation="fade-up"
+        data-animation-delay="350"
+      >
+        <div class="container">
+          <h2>Image Gallery</h2>
+          <p>
+            Replace these placeholders with stunning AI images to showcase your
+            creativity.
+          </p>
+          <div class="gallery-grid">
+            <img src="/images/gallery1.jpg" alt="placeholder image 1" />
+            <img src="/images/gallery2.jpg" alt="placeholder image 2" />
+            <img src="/images/gallery3.jpg" alt="placeholder image 3" />
+            <img src="/images/gallery4.jpg" alt="placeholder image 4" />
+          </div>
         </div>
-      </div>
-    </section>
-    <section class="marketing" data-animation="fade-up" data-animation-delay="375">
-      <div class="container">
-        <h2>Built for Every Tool</h2>
-        <p>Swap these icons with your own logos to highlight how ScalerMax plugs into any stack.</p>
-        <div class="icon-grid">
-          <img src="/images/icon1.png" alt="placeholder icon">
-          <img src="/images/icon2.png" alt="placeholder icon">
-          <img src="/images/icon3.png" alt="placeholder icon">
-          <img src="/images/icon4.png" alt="placeholder icon">
-          <img src="/images/icon5.png" alt="placeholder icon">
-          <img src="/images/icon6.png" alt="placeholder icon">
+      </section>
+      <section
+        class="marketing"
+        data-animation="fade-up"
+        data-animation-delay="375"
+      >
+        <div class="container">
+          <h2>Built for Every Tool</h2>
+          <p>
+            Swap these icons with your own logos to highlight how ScalerMax
+            plugs into any stack.
+          </p>
+          <div class="icon-grid">
+            <img src="/images/icon1.png" alt="placeholder icon" />
+            <img src="/images/icon2.png" alt="placeholder icon" />
+            <img src="/images/icon3.png" alt="placeholder icon" />
+            <img src="/images/icon4.png" alt="placeholder icon" />
+            <img src="/images/icon5.png" alt="placeholder icon" />
+            <img src="/images/icon6.png" alt="placeholder icon" />
+          </div>
         </div>
+      </section>
+      <section
+        class="marketing callout"
+        data-animation="fade-up"
+        data-animation-delay="400"
+      >
+        <h2>Ready to Experience the Power of ScalerMax?</h2>
+        <p>Join us today and let the automation do the heavy lifting.</p>
+        <a href="login.html" class="btn btn-primary" id="cta-start"
+          >Get Started</a
+        >
+      </section>
+    </main>
+    <footer class="site-footer">
+      <div class="container">
+        <p>&copy; 2025 ScalerMax. All rights reserved.</p>
       </div>
-    </section>
-    <section class="marketing callout" data-animation="fade-up" data-animation-delay="400">
-      <h2>Ready to Experience the Power of ScalerMax?</h2>
-      <p>Join us today and let the automation do the heavy lifting.</p>
-      <a href="login.html" class="btn btn-primary" id="cta-start">Get Started</a>
-    </section>
-  </main>
-  <footer class="site-footer">
-    <div class="container">
-      <p>&copy; 2025 ScalerMax. All rights reserved.</p>
-    </div>
-  </footer>
-  <script>
-    document.addEventListener('DOMContentLoaded', function () {
-      var heroBtn = document.getElementById('hero-start');
-      var ctaBtn = document.getElementById('cta-start');
-      var loginLink = document.getElementById('nav-login');
-      var brand = document.querySelector('.logo');
-      if (window.Glow) {
-        if (heroBtn) Glow.applyGlow(heroBtn, { color: '#9b5cf5', blur: 20, pulse: true });
-        if (ctaBtn) Glow.applyGlow(ctaBtn, { color: '#9b5cf5', blur: 20, pulse: true });
-        if (loginLink) Glow.applyGlow(loginLink, { color: '#9b5cf5', blur: 15, pulse: true });
-        if (brand) Glow.applyGlow(brand, { color: '#9b5cf5', blur: 8, pulse: false });
-      }
-    });
-  </script>
-</body>
+    </footer>
+    <script>
+      document.addEventListener("DOMContentLoaded", function () {
+        var heroBtn = document.getElementById("hero-start");
+        var ctaBtn = document.getElementById("cta-start");
+        var loginLink = document.getElementById("nav-login");
+        if (window.Glow) {
+          if (heroBtn)
+            Glow.applyGlow(heroBtn, {
+              color: "#9b5cf5",
+              blur: 20,
+              pulse: true,
+            });
+          if (ctaBtn)
+            Glow.applyGlow(ctaBtn, { color: "#9b5cf5", blur: 20, pulse: true });
+          if (loginLink)
+            Glow.applyGlow(loginLink, {
+              color: "#9b5cf5",
+              blur: 15,
+              pulse: true,
+            });
+        }
+      });
+    </script>
+  </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -1,98 +1,161 @@
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>
-Privacy Policy - ScalerMax Demo</title>
-  <link rel="stylesheet" href="styles.css">
-  <script defer src="headernav.js"></script>
-  <script defer src="glow.js"></script>
-</head>
-<body>
-  <a href="#main-content" class="skip-link">Skip to content</a>
-  <header class="site-header" data-animation="fade-up" data-animation-trigger="timed" data-animation-delay="100">
-    <div class="container">
-      <a href="index.html" class="logo">ScalerMax</a>
-      <button class="nav-toggle" data-nav-toggle aria-label="Open navigation" aria-expanded="false" aria-controls="primary-navigation">
-        <span class="hamburger"></span>
-      </button>
-      <nav id="primary-navigation" data-nav-menu class="site-nav" aria-label="Primary navigation">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Privacy Policy - ScalerMax Demo</title>
+    <link rel="stylesheet" href="styles.css" />
+    <script defer src="headernav.js"></script>
+    <script defer src="glow.js"></script>
+  </head>
+  <body>
+    <a href="#main-content" class="skip-link">Skip to content</a>
+    <header
+      class="site-header"
+      data-animation="fade-up"
+      data-animation-trigger="timed"
+      data-animation-delay="100"
+    >
+      <div class="container">
+        <a href="index.html" class="logo">ScalerMax</a>
+        <button
+          class="nav-toggle"
+          data-nav-toggle
+          aria-label="Open navigation"
+          aria-expanded="false"
+          aria-controls="primary-navigation"
+        >
+          <span class="hamburger"></span>
+        </button>
+        <nav
+          id="primary-navigation"
+          data-nav-menu
+          class="site-nav"
+          aria-label="Primary navigation"
+        >
+          <ul>
+            <li><a href="index.html">Home</a></li>
+            <li><a href="login.html">Login</a></li>
+            <li data-dashboard-link style="display: none">
+              <a href="dashboard.html">Dashboard</a>
+            </li>
+            <li><a href="privacy.html" aria-current="page">Privacy</a></li>
+          </ul>
+        </nav>
+        <button
+          id="theme-toggle"
+          class="theme-toggle"
+          aria-label="Toggle dark mode"
+        ></button>
+      </div>
+    </header>
+
+    <main id="main-content" class="site-main container">
+      <h1>Privacy Policy</h1>
+      <p>Effective Date: July 1, 2025</p>
+
+      <section>
+        <h2>1. Introduction</h2>
+        <p>
+          ScalerMax FE is a static, demo frontend designed to showcase the
+          ScalerMax AI Intent Server. We prioritize your privacy and do not
+          collect or store personal information through this demo application.
+        </p>
+      </section>
+
+      <section>
+        <h2>2. Information We Collect</h2>
+        <p>
+          No personal data is collected or stored. Any input you enter (e.g.,
+          chat messages) is sent directly to the ScalerMax AI API for real-time
+          processing and not retained on our servers.
+        </p>
+      </section>
+
+      <section>
+        <h2>3. Use of Data</h2>
+        <p>
+          All user inputs are used solely to provide interactive AI chat
+          functionality during your session. Once the session ends or the
+          browser is closed, no data persists.
+        </p>
+      </section>
+
+      <section>
+        <h2>4. Cookies, Tracking, and Local Storage</h2>
+        <p>
+          This demo does not use cookies, web beacons, or other tracking
+          technologies. We do not embed analytics or third-party trackers on
+          this site. However, we use localStorage to persist your theme
+          preference (light or dark mode) across sessions.
+        </p>
+      </section>
+
+      <section>
+        <h2>5. Third-Party Services</h2>
+        <p>
+          We utilize the ScalerMax AI Intent Server API to process chat
+          interactions. Please review the
+          <a
+            href="https://scalermax.ai/api-privacy-policy"
+            target="_blank"
+            rel="noopener noreferrer"
+            >ScalerMax API Privacy Policy</a
+          >
+          for details on their data handling practices.
+        </p>
+      </section>
+
+      <section>
+        <h2>6. Children's Privacy</h2>
+        <p>
+          This demo is not intended for use by children under 13. We do not
+          knowingly collect information from minors.
+        </p>
+      </section>
+
+      <section>
+        <h2>7. Policy Updates</h2>
+        <p>
+          We may update this Privacy Policy to reflect changes in technology or
+          legal requirements. The revised policy will include the effective
+          date.
+        </p>
+      </section>
+
+      <section>
+        <h2>8. Contact Us</h2>
+        <p>
+          For questions about this Privacy Policy, please contact us at
+          <a href="mailto:privacy@scalermax.ai">privacy@scalermax.ai</a>.
+        </p>
+      </section>
+      <nav class="page-nav">
         <ul>
           <li><a href="index.html">Home</a></li>
-          <li><a href="login.html">Login</a></li>
-          <li data-dashboard-link style="display:none;"><a href="dashboard.html">Dashboard</a></li>
-          <li><a href="privacy.html" aria-current="page">Privacy</a></li>
         </ul>
       </nav>
-      <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark mode"></button>
-    </div>
-  </header>
+    </main>
 
-  <main id="main-content" class="site-main container">
-    <h1>Privacy Policy</h1>
-    <p>Effective Date: July 1, 2025</p>
+    <footer class="site-footer container">
+      <p>
+        &copy; <span id="current-year"></span> ScalerMax. All rights reserved.
+      </p>
+    </footer>
 
-    <section>
-      <h2>1. Introduction</h2>
-      <p>ScalerMax FE is a static, demo frontend designed to showcase the ScalerMax AI Intent Server. We prioritize your privacy and do not collect or store personal information through this demo application.</p>
-    </section>
-
-    <section>
-      <h2>2. Information We Collect</h2>
-      <p>No personal data is collected or stored. Any input you enter (e.g., chat messages) is sent directly to the ScalerMax AI API for real-time processing and not retained on our servers.</p>
-    </section>
-
-    <section>
-      <h2>3. Use of Data</h2>
-      <p>All user inputs are used solely to provide interactive AI chat functionality during your session. Once the session ends or the browser is closed, no data persists.</p>
-    </section>
-
-    <section>
-      <h2>4. Cookies, Tracking, and Local Storage</h2>
-      <p>This demo does not use cookies, web beacons, or other tracking technologies. We do not embed analytics or third-party trackers on this site. However, we use localStorage to persist your theme preference (light or dark mode) across sessions.</p>
-    </section>
-
-    <section>
-      <h2>5. Third-Party Services</h2>
-      <p>We utilize the ScalerMax AI Intent Server API to process chat interactions. Please review the <a href="https://scalermax.ai/api-privacy-policy" target="_blank" rel="noopener noreferrer">ScalerMax API Privacy Policy</a> for details on their data handling practices.</p>
-    </section>
-
-    <section>
-      <h2>6. Children's Privacy</h2>
-      <p>This demo is not intended for use by children under 13. We do not knowingly collect information from minors.</p>
-    </section>
-
-    <section>
-      <h2>7. Policy Updates</h2>
-      <p>We may update this Privacy Policy to reflect changes in technology or legal requirements. The revised policy will include the effective date.</p>
-    </section>
-
-    <section>
-      <h2>8. Contact Us</h2>
-      <p>For questions about this Privacy Policy, please contact us at <a href="mailto:privacy@scalermax.ai">privacy@scalermax.ai</a>.</p>
-    </section>
-  </main>
-
-  <footer class="site-footer container">
-    <p>&copy; <span id="current-year"></span> ScalerMax. All rights reserved.</p>
-  </footer>
-
-  <script>
-    document.getElementById('current-year').textContent = new Date().getFullYear();
-    const toggle = document.getElementById('theme-toggle');
-    const root = document.documentElement;
-    const storedTheme = localStorage.getItem('theme');
-    if (storedTheme) root.setAttribute('data-theme', storedTheme);
-    toggle.addEventListener('click', () => {
-      const current = root.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
-      root.setAttribute('data-theme', current);
-      localStorage.setItem('theme', current);
-    });
-    const brand = document.querySelector('.logo');
-    if (window.Glow && brand) {
-      Glow.applyGlow(brand, { color: '#9b5cf5', blur: 8, pulse: false });
-    }
-  </script>
-</body>
+    <script>
+      document.getElementById("current-year").textContent =
+        new Date().getFullYear();
+      const toggle = document.getElementById("theme-toggle");
+      const root = document.documentElement;
+      const storedTheme = localStorage.getItem("theme");
+      if (storedTheme) root.setAttribute("data-theme", storedTheme);
+      toggle.addEventListener("click", () => {
+        const current =
+          root.getAttribute("data-theme") === "dark" ? "light" : "dark";
+        root.setAttribute("data-theme", current);
+        localStorage.setItem("theme", current);
+      });
+    </script>
+  </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -10,11 +10,13 @@
   --color-text: #e0e0e0;
   --color-text-light: #b0b0b0;
   --color-border: #36304b;
-  --font-sans: 'Inter', sans-serif;
+  --font-sans: "Inter", sans-serif;
   --transition-fast: 0.2s ease-in-out;
   --transition-medium: 0.4s ease-in-out;
 }
-*, *::before, *::after {
+*,
+*::before,
+*::after {
   margin: 0;
   padding: 0;
   box-sizing: border-box;
@@ -33,7 +35,8 @@ a {
   color: inherit;
   text-decoration: none;
 }
-img, svg {
+img,
+svg {
   display: block;
   max-width: 100%;
 }
@@ -54,24 +57,23 @@ header {
   right: 0;
   height: 4rem;
   background-color: var(--color-header-bg);
-  box-shadow: 0 1px 4px rgba(0,0,0,0.1);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
   display: flex;
   align-items: center;
   padding: 0 1.5rem;
   z-index: 100;
 }
-.site-header .container{
-  display:flex;
-  align-items:center;
-  justify-content:space-between;
-  width:100%;
+.site-header .container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
 }
 .logo {
   font-size: 1.25rem;
   font-weight: 700;
   color: #9b5cf5;
-  text-shadow: 0 0 8px rgba(155, 92, 245, 0.6);
-  margin-right:auto;
+  margin-right: auto;
 }
 
 /* Navigation menu */
@@ -85,7 +87,7 @@ header {
 .hamburger,
 .hamburger::before,
 .hamburger::after {
-  content: '';
+  content: "";
   position: absolute;
   left: 0;
   right: 0;
@@ -97,11 +99,21 @@ header {
   top: 50%;
   transform: translateY(-50%);
 }
-.hamburger::before { top: -6px; }
-.hamburger::after { top: 6px; }
-.nav-toggle.is-open .hamburger { background: transparent; }
-.nav-toggle.is-open .hamburger::before { transform: translateY(6px) rotate(45deg); }
-.nav-toggle.is-open .hamburger::after { transform: translateY(-6px) rotate(-45deg); }
+.hamburger::before {
+  top: -6px;
+}
+.hamburger::after {
+  top: 6px;
+}
+.nav-toggle.is-open .hamburger {
+  background: transparent;
+}
+.nav-toggle.is-open .hamburger::before {
+  transform: translateY(6px) rotate(45deg);
+}
+.nav-toggle.is-open .hamburger::after {
+  transform: translateY(-6px) rotate(-45deg);
+}
 
 .site-nav ul {
   display: flex;
@@ -113,7 +125,9 @@ header {
   font-size: 0.95rem;
   font-weight: 500;
   color: var(--color-text-light);
-  transition: color var(--transition-fast), text-shadow var(--transition-fast);
+  transition:
+    color var(--transition-fast),
+    text-shadow var(--transition-fast);
 }
 .site-nav a:hover {
   color: #fff;
@@ -126,7 +140,9 @@ header {
 }
 
 @media (max-width: 768px) {
-  .nav-toggle { display: block; }
+  .nav-toggle {
+    display: block;
+  }
   .site-nav {
     position: absolute;
     top: 100%;
@@ -135,13 +151,18 @@ header {
     background: var(--color-header-bg);
     transform: translateY(-200%);
     opacity: 0;
-    transition: transform var(--transition-medium), opacity var(--transition-medium);
+    transition:
+      transform var(--transition-medium),
+      opacity var(--transition-medium);
   }
   .site-nav.is-open {
     transform: translateY(0);
     opacity: 1;
   }
-  .site-nav ul { flex-direction: column; padding: 1rem; }
+  .site-nav ul {
+    flex-direction: column;
+    padding: 1rem;
+  }
 }
 .sidebar {
   position: fixed;
@@ -160,12 +181,14 @@ header {
   padding: 0.75rem 1.5rem;
   font-size: 0.875rem;
   color: var(--color-sidebar-text);
-  transition: background var(--transition-fast), box-shadow var(--transition-fast);
+  transition:
+    background var(--transition-fast),
+    box-shadow var(--transition-fast);
 }
 .sidebar nav a:hover,
 .sidebar nav a.active {
-  background-color: rgba(155,92,245,0.2);
-  box-shadow: 0 0 6px rgba(155,92,245,0.6);
+  background-color: rgba(155, 92, 245, 0.2);
+  box-shadow: 0 0 6px rgba(155, 92, 245, 0.6);
   color: #fff;
 }
 .main {
@@ -196,12 +219,14 @@ header {
   border: 1px solid var(--color-border);
   border-radius: 0.5rem;
   padding: 1.5rem;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
   animation: fadeIn var(--transition-medium) forwards;
   opacity: 0;
 }
 @keyframes fadeIn {
-  to { opacity: 1; }
+  to {
+    opacity: 1;
+  }
 }
 .metric-card {
   display: flex;
@@ -268,7 +293,9 @@ header {
   animation: growBar var(--transition-medium) forwards;
 }
 @keyframes growBar {
-  to { transform: scaleY(calc(var(--value, 0) / 100)); }
+  to {
+    transform: scaleY(calc(var(--value, 0) / 100));
+  }
 }
 .pie-chart {
   position: relative;
@@ -297,7 +324,9 @@ header {
   animation: spinPie var(--transition-medium) forwards;
 }
 @keyframes spinPie {
-  to { stroke-dashoffset: calc(440 - (440 * var(--percent) / 100)); }
+  to {
+    stroke-dashoffset: calc(440 - (440 * var(--percent) / 100));
+  }
 }
 .table {
   width: 100%;
@@ -326,7 +355,7 @@ header {
   transition: background var(--transition-fast);
 }
 .button:hover {
-  background-color: hsl(219,93%,55%);
+  background-color: hsl(219, 93%, 55%);
 }
 a:focus,
 button:focus,
@@ -359,7 +388,9 @@ button:focus,
   margin: 2rem auto;
 }
 @keyframes spinLoader {
-  to { transform: rotate(360deg); }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 /* Login form styling */
@@ -428,7 +459,9 @@ button:focus,
   color: #fff;
   font-size: 0.875rem;
   border-radius: 0.375rem;
-  transition: box-shadow var(--transition-fast), background var(--transition-fast);
+  transition:
+    box-shadow var(--transition-fast),
+    background var(--transition-fast);
 }
 
 .btn:hover {
@@ -451,7 +484,11 @@ button:focus,
   align-items: center;
   justify-content: center;
   text-align: center;
-  background: radial-gradient(circle at 30% 30%, rgba(155, 92, 245, 0.4), var(--color-bg) 70%);
+  background: radial-gradient(
+    circle at 30% 30%,
+    rgba(155, 92, 245, 0.4),
+    var(--color-bg) 70%
+  );
   overflow: hidden;
 }
 
@@ -535,7 +572,7 @@ button:focus,
 }
 
 /* Simple fade-up animation */
-[data-animation='fade-up'] {
+[data-animation="fade-up"] {
   opacity: 0;
   transform: translateY(2rem);
 }
@@ -617,6 +654,21 @@ button:focus,
 }
 
 @keyframes pulseGlow {
-  0%, 100% { text-shadow: 0 0 8px rgba(155, 92, 245, 0.6); }
-  50% { text-shadow: 0 0 12px rgba(155, 92, 245, 1); }
+  0%,
+  100% {
+    text-shadow: 0 0 8px rgba(155, 92, 245, 0.6);
+  }
+  50% {
+    text-shadow: 0 0 12px rgba(155, 92, 245, 1);
+  }
+}
+
+.page-nav {
+  margin-top: 2rem;
+  text-align: center;
+}
+
+.page-nav a {
+  color: #9b5cf5;
+  text-decoration: underline;
 }


### PR DESCRIPTION
## Summary
- remove glow effect on menu logo
- hide glow JS call for menu logo
- add simple navigation back to Home on privacy page

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint config missing)*
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68656e2bc5a48327af3e4cf24f3af652