### PR TITLE
Add home nav to privacy page

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -51,6 +51,11 @@
     </header>
 
     <main id="main-content" class="site-main container">
+      <nav class="page-nav">
+        <ul>
+          <li><a href="index.html">Home</a></li>
+        </ul>
+      </nav>
       <h1>Privacy Policy</h1>
       <p>Effective Date: July 1, 2025</p>
 


### PR DESCRIPTION
## Summary
- add a Home link menu to the top of `privacy.html`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run type-check`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6865739833e48327b3f83294bdc5cb34