### PR TITLE
Unify header nav and clean privacy page

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -39,18 +39,13 @@
             <li data-dashboard-link style="display: none">
               <a href="dashboard.html">Dashboard</a>
             </li>
-            <li><a href="privacy.html" aria-current="page">Privacy</a></li>
+            <li><a href="privacy.html">Privacy</a></li>
           </ul>
         </nav>
       </div>
     </header>
 
     <main id="main-content" class="site-main container">
-      <nav class="page-nav">
-        <ul>
-          <li><a href="index.html">Home</a></li>
-        </ul>
-      </nav>
       <h1>Privacy Policy</h1>
       <p>Effective Date: July 1, 2025</p>
 
@@ -130,11 +125,6 @@
           <a href="mailto:privacy@scalermax.ai">privacy@scalermax.ai</a>.
         </p>
       </section>
-      <nav class="page-nav">
-        <ul>
-          <li><a href="index.html">Home</a></li>
-        </ul>
-      </nav>
     </main>
 
     <footer class="site-footer container">


### PR DESCRIPTION
## Summary
- match the header navigation markup between `index.html` and `privacy.html`
- remove extra `Home` links from the privacy page

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686579b8b52c8327a5d01d5795f51887