### PR TITLE
Fix mobile menu on privacy page

### DIFF
--- a/headernav.js
+++ b/headernav.js
@@ -49,6 +49,7 @@ let menuToggle, navMenu;
   }
 
   function initHeaderNav() {
+    console.log('[headernav] loaded');
     menuToggle = document.querySelector('[data-nav-toggle]');
     navMenu = document.querySelector('[data-nav-menu]');
     if (!menuToggle || !navMenu) return;

--- a/privacy.html
+++ b/privacy.html
@@ -42,6 +42,14 @@
             <li><a href="privacy.html">Privacy</a></li>
           </ul>
         </nav>
+        <noscript>
+          <style>
+            .site-nav {
+              transform: none !important;
+              opacity: 1 !important;
+            }
+          </style>
+        </noscript>
       </div>
     </header>
 


### PR DESCRIPTION
## Summary
- log script initialization in `headernav.js`
- add `<noscript>` CSS fallback to `privacy.html`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint config missing)*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_686583a2256c83279db1f0f133da7113