### PR TITLE
Fix header navigation on privacy page

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -6,6 +6,7 @@
     <title>Privacy Policy - ScalerMax Demo</title>
     <link rel="stylesheet" href="styles.css" />
     <script defer src="headernav.js"></script>
+    <script defer src="animationsmanager.js"></script>
     <script defer src="glow.js"></script>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- ensure the animation script loads on `privacy.html` so the header becomes visible

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68659a31d2e88327a1d07b80a5ec4e18