### PR TITLE
Improve chat UI and error handling

### DIFF
--- a/chat.js
+++ b/chat.js
@@ -99,7 +99,14 @@
             body: JSON.stringify({ prompt }),
             signal
         });
-        if (!res.ok) throw new Error(res.statusText || 'Network response was not ok');
+        if (!res.ok) {
+            let errMsg = res.statusText;
+            try {
+                const errData = await res.json();
+                if (errData && errData.error) errMsg = errData.error;
+            } catch {}
+            throw new Error(errMsg || 'Network response was not ok');
+        }
         if (!res.body) throw new Error('ReadableStream not supported in this browser.');
         const reader = res.body.getReader();
         const decoder = new TextDecoder();

--- a/dashboard.html
+++ b/dashboard.html
@@ -140,6 +140,8 @@
     #chat-input {
       flex: 1;
       font-size: 1.05rem;
+      min-height: 3.5rem;
+      min-width: 250px;
     }
 
     #chat-form .glow-button {
@@ -228,7 +230,7 @@
         <div class="card chat-card text-light">
           <div id="chat-container" class="mb-2" aria-live="polite" role="log"></div>
           <form id="chat-form" class="d-flex gap-2">
-            <input id="chat-input" type="text" class="glow-input flex-grow-1" placeholder="Type a message..." aria-label="chat input" disabled>
+            <textarea id="chat-input" class="glow-input flex-grow-1" placeholder="Type a message..." aria-label="chat input" rows="3" disabled></textarea>
             <button id="send-button" class="glow-button" type="submit" disabled>Send</button>
           </form>
         </div>
@@ -297,7 +299,7 @@
           <div class="card-counter">
             <div>
               <div class="card-title">Error Rate</div>
-              <div class="count"><span class="counter" data-target="2.5" data-decimals="1" data-metric="errorRate">0</span><span>%</span></div>
+              <div class="count"><span class="counter" data-target="1.5" data-decimals="1" data-min="0" data-max="1.9" data-metric="errorRate">0</span><span>%</span></div>
             </div>
             <div class="icon"></div>
           </div>

--- a/openrouterclient.js
+++ b/openrouterclient.js
@@ -56,10 +56,12 @@ async function sendRequest(model, prompt, options = {}) {
           messages: [{ role: 'user', content: prompt }],
         }),
       });
-      const data = await response.json();
+      const text = await response.text();
+      let data;
+      try { data = JSON.parse(text); } catch { data = {}; }
       if (!response.ok) {
-        const msg = data.error?.message || response.statusText;
-        throw new Error(`OpenRouter API error: ${msg}`);
+        const msg = data.error?.message || text || response.statusText;
+        throw new Error(`OpenRouter API error ${response.status}: ${msg}`);
       }
       const content = data.choices?.[0]?.message?.content;
       if (typeof content !== 'string') {


### PR DESCRIPTION
## Summary
- keep error rate demo metric under 2%
- enlarge chat text input
- surface detailed API errors on the frontend and backend

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865a28868008327ab39941d2f5497a4