### PR TITLE
Hide header on dashboard

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -17,7 +17,8 @@
     .sidebar-desktop a { color: #d1c4e9; padding: .75rem 1.25rem; display: block; text-decoration: none; }
     .sidebar-desktop a.active, .sidebar-desktop a:hover { color: #fff; background-color: #371c59; }
     .sidebar-logo { font-size: 1.5rem; color: #fff; font-weight: bold; }
-    main { margin-top: 0; margin-left: 240px; padding: 1rem; }
+    .site-header { display: none; }
+        main { margin-top: 0; margin-left: 240px; padding: 1rem; }
     @media (max-width: 768px) {
       .sidebar-desktop { display: none; }
       main { margin-left: 0; }


### PR DESCRIPTION
## Summary
- hide the standard header menu on the dashboard

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865a5d66d708327a2d7678f293be200