### PR TITLE
Improve server error handling

### DIFF
--- a/chat.js
+++ b/chat.js
@@ -83,7 +83,8 @@
             if (err.name === 'AbortError') {
                 aiEl.textContent = 'Error: Request timed out';
             } else {
-                aiEl.textContent = 'Error: ' + err.message;
+                aiEl.textContent = `⚠️ ${err.message}`;
+                aiEl.classList.add('message-system');
             }
             scrollToBottom();
         } finally {
@@ -100,12 +101,17 @@
             signal
         });
         if (!res.ok) {
-            let errMsg = res.statusText;
+            let errorMessage = `Error ${res.status}: ${res.statusText}`;
             try {
-                const errData = await res.json();
-                if (errData && errData.error) errMsg = errData.error;
-            } catch {}
-            throw new Error(errMsg || 'Network response was not ok');
+                const errorData = await res.json();
+                if (errorData?.error) {
+                    errorMessage = `❌ ${errorData.error}`;
+                }
+            } catch {
+                const raw = await res.text();
+                if (raw) errorMessage = `❌ ${raw}`;
+            }
+            throw new Error(errorMessage);
         }
         if (!res.body) throw new Error('ReadableStream not supported in this browser.');
         const reader = res.body.getReader();

--- a/scalermax-api.js
+++ b/scalermax-api.js
@@ -78,7 +78,7 @@ exports.handler = async function(event, context) {
   }
   const clientApiKey = headers['x-api-key'];
   if (!clientApiKey || clientApiKey !== AUTH_API_KEY) {
-    return errorResponse(401, 'Unauthorized');
+    return errorResponse(401, 'Unauthorized: x-api-key header missing or invalid');
   }
   const clientId = headers['x-forwarded-for'] || headers['x-nf-client-connection-ip'] || 'unknown';
   const now = Date.now();
@@ -104,14 +104,14 @@ exports.handler = async function(event, context) {
   let temperature = typeof body.temperature === 'number' ? body.temperature : 0.7;
   temperature = Math.min(Math.max(temperature, 0.0), 1.0);
   if (!prompt || typeof prompt !== 'string') {
-    return errorResponse(400, 'Missing prompt');
+    return errorResponse(400, 'Missing prompt in request body');
   }
   if (prompt.length > MAX_PROMPT_LENGTH) {
     return errorResponse(400, `Prompt too long (max ${MAX_PROMPT_LENGTH} characters)`);
   }
   if (!OPENROUTER_API_KEY) {
     logError('Missing OPENROUTER_API_KEY');
-    return errorResponse(500, 'Server misconfiguration');
+    return errorResponse(500, 'Server misconfiguration: Missing OPENROUTER_API_KEY');
   }
   const intent = classifyPrompt(prompt);
   const route = ROUTER_CONFIG[intent] || ROUTER_CONFIG.planning;


### PR DESCRIPTION
## Summary
- enhance chat error handling with better frontend display
- send detailed errors from the backend

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865a94d3b788327b807db7f6bf864fb