### PR TITLE
Update admin dashboard layout

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -36,7 +36,7 @@ ScalerMax Admin Dashboard</title>
 <body>
   <div class="container">
     <header>
-      <h1>ScalerMax Dashboard</h1>
+      <h1>ScalerMax Super Admin</h1>
       <div class="last-updated">Last updated: <span id="lastUpdated"></span></div>
     </header>
     <section class="stats-cards">
@@ -60,10 +60,6 @@ ScalerMax Admin Dashboard</title>
         <h3>CPU Usage</h3>
         <p id="cpuUsage" class="value">0%</p>
       </div>
-      <div class="card">
-        <h3>Memory Usage</h3>
-        <p id="memoryUsage" class="value">0%</p>
-      </div>
     </section>
     <section class="charts">
       <div class="chart-container" data-animation="fade-up" data-animation-delay="100">
@@ -83,6 +79,10 @@ ScalerMax Admin Dashboard</title>
           <canvas id="responseTimeChart">Your browser does not support the canvas element.</canvas>
           <figcaption>Average response time by model</figcaption>
         </figure>
+      </div>
+      <div class="chart-container" id="topAccountsContainer" data-animation="fade-up" data-animation-delay="400">
+        <h3 style="text-align:center;margin-bottom:10px;">Top Active Accounts</h3>
+        <ul id="topAccountsList" style="list-style:none;padding:0;margin:0;text-align:center;"></ul>
       </div>
     </section>
   </div>
@@ -110,8 +110,7 @@ ScalerMax Admin Dashboard</title>
         {id:'requestsPerMinute',suffix:'',isAccum:false,min:20,max:200},
         {id:'avgResponseTime',suffix:'ms',isAccum:false,min:100,max:600},
         {id:'routingAccuracy',suffix:'%',isAccum:false,min:80,max:100},
-        {id:'cpuUsage',suffix:'%',isAccum:false,min:10,max:90},
-        {id:'memoryUsage',suffix:'%',isAccum:false,min:20,max:95}
+        {id:'cpuUsage',suffix:'%',isAccum:false,min:10,max:90}
       ];
       let metricsState = {}, metricEls = {}, lastUpdatedEl;
       function initMetrics(){
@@ -149,6 +148,20 @@ ScalerMax Admin Dashboard</title>
         lastUpdatedEl = document.getElementById('lastUpdated');
         initMetrics();
         lastUpdatedEl.innerText = new Date().toLocaleTimeString();
+        const sampleNames = ['Alice','Bob','Carol','Dave','Eve','Frank'];
+        function updateTopAccountsList(){
+          const list = document.getElementById('topAccountsList');
+          if(!list) return;
+          list.innerHTML = '';
+          for(let i=0;i<3;i++){
+            const name = sampleNames[Math.floor(Math.random()*sampleNames.length)];
+            const usage = adminRandomInt(50,200);
+            const li = document.createElement('li');
+            li.textContent = name + ' - ' + usage + ' reqs';
+            list.appendChild(li);
+          }
+        }
+        updateTopAccountsList();
         const models = ['GPT-4','GPT-3.5','Claude','Bard'];
         const rpmLabels = Array.from({length:10},(_,i)=>new Date(Date.now()-(9-i)*5000).toLocaleTimeString());
         const rpmData = rpmLabels.map(()=>adminRandomInt(30,150));
@@ -188,6 +201,7 @@ ScalerMax Admin Dashboard</title>
           if(rpmChart){ rpmChart.data.labels = rpmLabels; rpmChart.data.datasets[0].data = rpmData; rpmChart.update(); }
           if(distChart){ distChart.data.datasets[0].data = randomDistribution(models.length); distChart.update(); }
           if(barChart){ barChart.data.datasets[0].data = models.map(()=>adminRandomInt(100,600)); barChart.update(); }
+          updateTopAccountsList();
         },5000);
       });
     })();

--- a/dashboard.html
+++ b/dashboard.html
@@ -226,49 +226,43 @@
     </div>
   </section>
     <div class="row">
-      <div class="col-lg-4 order-lg-1 mb-4">
+      <div class="col-lg-6 offset-lg-3 mb-4 text-center">
         <h2>Chat Demo</h2>
         <div class="card chat-card text-light">
           <div id="chat-container" class="mb-2" aria-live="polite" role="log"></div>
-          <form id="chat-form" class="d-flex gap-2">
-            <textarea id="chat-input" class="glow-input flex-grow-1" placeholder="Type a message..." aria-label="chat input" rows="3" disabled></textarea>
+          <form id="chat-form" class="d-flex flex-column gap-2 align-items-center">
+            <textarea id="chat-input" class="glow-input w-100" placeholder="Type a message..." aria-label="chat input" rows="3" disabled></textarea>
             <button id="send-button" class="glow-button" type="submit" disabled>Send</button>
           </form>
         </div>
       </div>
       <div class="col-lg-8 order-lg-2">
-        <div class="d-flex justify-content-between align-items-center mb-4">
+        <div class="mb-2 d-flex justify-content-between align-items-center">
           <h1 class="h2 m-0">Dashboard</h1>
-          <div>
-            <button id="refreshBtn" class="btn btn-sm btn-outline-secondary">Refresh</button>
-          </div>
+        </div>
+        <div class="text-center mb-4">
+          <button id="refreshBtn" class="btn btn-outline-secondary">Refresh</button>
         </div>
         <div class="card p-3 mb-4">
           <h5 class="mb-4">Your Project Keys</h5>
-          <div class="row row-cols-1 row-cols-md-3 g-3">
-            <div class="col">
-              <div class="tile card h-100 text-center p-3">
-                <h5 class="mb-2">VibeSheet</h5>
-                <span class="badge bg-success mb-2">✅ Active</span>
-                <p class="small text-muted">Requests Today: <strong>128</strong></p>
-                <p class="small text-muted">Failures: <strong>1</strong></p>
-              </div>
+          <div class="project-keys d-grid gap-3" style="grid-template-columns:repeat(3,1fr);">
+            <div class="tile card h-100 text-center p-3">
+              <h5 class="mb-2">VibeSheet</h5>
+              <span class="badge bg-success mb-2">✅ Active</span>
+              <p class="small text-muted">Requests Today: <strong>128</strong></p>
+              <p class="small text-muted">Failures: <strong>1</strong></p>
             </div>
-            <div class="col">
-              <div class="tile card h-100 text-center p-3">
-                <h5 class="mb-2">AahSheet</h5>
-                <span class="badge bg-success mb-2">✅ Active</span>
-                <p class="small text-muted">Requests Today: <strong>64</strong></p>
-                <p class="small text-muted">Failures: <strong>0</strong></p>
-              </div>
+            <div class="tile card h-100 text-center p-3">
+              <h5 class="mb-2">AahSheet</h5>
+              <span class="badge bg-success mb-2">✅ Active</span>
+              <p class="small text-muted">Requests Today: <strong>64</strong></p>
+              <p class="small text-muted">Failures: <strong>0</strong></p>
             </div>
-            <div class="col">
-              <div class="tile card h-100 text-center p-3">
-                <h5 class="mb-2">AI Tool</h5>
-                <span class="badge bg-success mb-2">✅ Active</span>
-                <p class="small text-muted">Requests Today: <strong>89</strong></p>
-                <p class="small text-muted">Failures: <strong>2</strong></p>
-              </div>
+            <div class="tile card h-100 text-center p-3">
+              <h5 class="mb-2">AI Tool</h5>
+              <span class="badge bg-success mb-2">✅ Active</span>
+              <p class="small text-muted">Requests Today: <strong>89</strong></p>
+              <p class="small text-muted">Failures: <strong>2</strong></p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- center refresh button and make it normal sized
- render project keys in three-tile grid
- center chat demo and inputs
- rename admin page header and remove memory usage card
- add demo tile listing top active accounts

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_6865ae1863f483279becae0311974602