### PR TITLE
Improve OpenRouter failure handling

### DIFF
--- a/chat.js
+++ b/chat.js
@@ -101,17 +101,8 @@
             signal
         });
         if (!res.ok) {
-            let errorMessage = `Error ${res.status}: ${res.statusText}`;
-            try {
-                const errorData = await res.json();
-                if (errorData?.error) {
-                    errorMessage = `❌ ${errorData.error}`;
-                }
-            } catch {
-                const raw = await res.text();
-                if (raw) errorMessage = `❌ ${raw}`;
-            }
-            throw new Error(errorMessage);
+            const text = await res.text();
+            throw new Error(`AI Server error ${res.status}: ${text}`);
         }
         if (!res.body) throw new Error('ReadableStream not supported in this browser.');
         const reader = res.body.getReader();

--- a/netlify/functions/healthcheck.js
+++ b/netlify/functions/healthcheck.js
@@ -1,0 +1,14 @@
+exports.handler = async function() {
+  try {
+    const res = await fetch('https://openrouter.ai/');
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ status: res.status }),
+    };
+  } catch (err) {
+    return {
+      statusCode: 502,
+      body: JSON.stringify({ error: err.message }),
+    };
+  }
+};

--- a/scalermax-api.js
+++ b/scalermax-api.js
@@ -103,15 +103,17 @@ exports.handler = async function(event, context) {
   const userId = body.userId;
   let temperature = typeof body.temperature === 'number' ? body.temperature : 0.7;
   temperature = Math.min(Math.max(temperature, 0.0), 1.0);
-  if (!prompt || typeof prompt !== 'string') {
-    return errorResponse(400, 'Missing prompt in request body');
+
+  if (!OPENROUTER_API_KEY) {
+    console.error('❌ Missing OPENROUTER_API_KEY in environment');
+    return errorResponse(500, 'Server misconfiguration: missing OpenRouter API key');
+  }
+
+  if (!prompt || typeof prompt !== 'string' || !prompt.trim()) {
+    return errorResponse(400, 'Missing or empty prompt');
   }
   if (prompt.length > MAX_PROMPT_LENGTH) {
     return errorResponse(400, `Prompt too long (max ${MAX_PROMPT_LENGTH} characters)`);
-  }
-  if (!OPENROUTER_API_KEY) {
-    logError('Missing OPENROUTER_API_KEY');
-    return errorResponse(500, 'Server misconfiguration: Missing OPENROUTER_API_KEY');
   }
   const intent = classifyPrompt(prompt);
   const route = ROUTER_CONFIG[intent] || ROUTER_CONFIG.planning;


### PR DESCRIPTION
## Summary
- add retries and detailed logs in `openrouterclient.js`
- validate prompt and API key early in `scalermax-api.js`
- surface backend errors to UI from `chat.js`
- add a Netlify healthcheck function

## Testing
- `npm test` *(fails: vitest not found due to no network access)*

------
https://chatgpt.com/codex/tasks/task_e_6865b3f331a08327a25992262d8c941e