### PR TITLE
Fix request logging crash

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -40,6 +40,7 @@ function safeStringify(obj) {
 }
 
 function truncate(data) {
+  if (data == null) return ''
   if (typeof data === 'string') {
     return data.length > MAX_BODY_LENGTH ? data.slice(0, MAX_BODY_LENGTH) + '...' : data
   }
@@ -75,7 +76,7 @@ function logRequest(event) {
       method,
       path,
       headers: maskSensitive(headers || {}),
-      query: truncate(maskSensitive(query || {})),
+      query: truncate(maskSensitive(query || {})) || {},
       body: truncate(maskSensitive(parsedBody))
     }
   }

--- a/scalermax-api.js
+++ b/scalermax-api.js
@@ -58,14 +58,6 @@ exports.handler = async function(event, context) {
     acc[key.toLowerCase()] = event.headers[key];
     return acc;
   }, {});
-  logRequest({
-    method: event.httpMethod,
-    path: event.path || '/',
-    headers: {
-      'user-agent': headers['user-agent'],
-      'x-forwarded-for': headers['x-forwarded-for'] || headers['x-nf-client-connection-ip']
-    }
-  });
   if (event.httpMethod === 'OPTIONS') {
     return { statusCode: 200, headers: CORS_HEADERS, body: '' };
   }
@@ -99,6 +91,16 @@ exports.handler = async function(event, context) {
     logError(err);
     return errorResponse(400, 'Invalid JSON');
   }
+  logRequest({
+    httpMethod: event.httpMethod,
+    path: event.path || '/',
+    headers: {
+      'user-agent': headers['user-agent'],
+      'x-forwarded-for': headers['x-forwarded-for'] || headers['x-nf-client-connection-ip']
+    },
+    queryStringParameters: event.queryStringParameters,
+    body
+  });
   const prompt = body.prompt;
   const userId = body.userId;
   let temperature = typeof body.temperature === 'number' ? body.temperature : 0.7;


### PR DESCRIPTION
## Summary
- guard `truncate` for null or undefined inputs
- default empty object for logged queries
- log request after body parse to avoid undefined inputs

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint config missing)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_6865b73355008327bfbed862dda15df8