### PR TITLE
Fix dashboard layout and streamline demo notice

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -312,6 +312,54 @@
     <main role="main" class="container-fluid">
       <div class="row mb-4">
         <div class="col-lg-6">
+          <section class="highlight-box">
+            <div class="highlight-inner">
+              <h2>Connect Your AI Provider</h2>
+              <p class="subtitle">Connect your accounts to get started.</p>
+
+              <div class="button-row">
+                <button onclick="showDemoText()" class="glow-button">
+                  OpenAI
+                </button>
+                <button onclick="showDemoText()" class="glow-button">
+                  Gemini
+                </button>
+                <button onclick="showDemoText()" class="glow-button">
+                  Claude
+                </button>
+                <button onclick="showDemoText()" class="glow-button">
+                  OpenRouter
+                </button>
+                <button onclick="showDemoText()" class="glow-button">
+                  Straico
+                </button>
+              </div>
+
+              <p id="demoMessage" class="demo-note" style="display: none">
+                🔒 Demo Only
+              </p>
+
+              <div class="key-input-wrap">
+                <h3>
+                  ScalerMax Key -
+                  <span style="color: #9b5cf5">Build Smart Tools Faster!</span>
+                </h3>
+                <div class="key-form">
+                  <input
+                    type="text"
+                    placeholder="Name of Key"
+                    class="key-input"
+                  />
+                  <button onclick="showDemoMessage()" class="glow-button">
+                    Get Key
+                  </button>
+                </div>
+                <!-- demoMessage reused for key status -->
+              </div>
+            </div>
+          </section>
+        </div>
+        <div class="col-lg-6">
           <div class="chat-wrapper mb-4 text-center">
             <h2>Chat Demo</h2>
             <div class="card chat-card text-light">
@@ -344,83 +392,6 @@
               </form>
             </div>
           </div>
-        </div>
-        <div class="col-lg-6">
-          <section class="highlight-box">
-            <div class="highlight-inner">
-              <h2>Connect Your AI Provider</h2>
-              <p class="subtitle">Connect your accounts to get started.</p>
-
-              <div class="button-row">
-                <button
-                  onclick="showDemoText('demo-openai')"
-                  class="glow-button"
-                >
-                  OpenAI
-                </button>
-                <button
-                  onclick="showDemoText('demo-gemini')"
-                  class="glow-button"
-                >
-                  Gemini
-                </button>
-                <button
-                  onclick="showDemoText('demo-claude')"
-                  class="glow-button"
-                >
-                  Claude
-                </button>
-                <button
-                  onclick="showDemoText('demo-openrouter')"
-                  class="glow-button"
-                >
-                  OpenRouter
-                </button>
-                <button
-                  onclick="showDemoText('demo-straico')"
-                  class="glow-button"
-                >
-                  Straico
-                </button>
-              </div>
-
-              <div id="demo-openai" class="demo-note" style="display: none">
-                🔒 Demo Only
-              </div>
-              <div id="demo-gemini" class="demo-note" style="display: none">
-                🔒 Demo Only
-              </div>
-              <div id="demo-claude" class="demo-note" style="display: none">
-                🔒 Demo Only
-              </div>
-              <div id="demo-openrouter" class="demo-note" style="display: none">
-                🔒 Demo Only
-              </div>
-              <div id="demo-straico" class="demo-note" style="display: none">
-                🔒 Demo Only
-              </div>
-
-              <div class="key-input-wrap">
-                <h3>
-                  ScalerMax Key -
-                  <span style="color: #9b5cf5">Build Smart Tools Faster!</span>
-                </h3>
-                <div class="key-form">
-                  <input
-                    type="text"
-                    placeholder="Name of Key"
-                    class="key-input"
-                  />
-                  <button onclick="showDemoMessage()" class="glow-button">
-                    Get Key
-                  </button>
-                </div>
-                <p id="keyStatus" class="demo-note" style="display: none">
-                  🔒 Demo Only
-                </p>
-              </div>
-            </div>
-          </section>
         </div>
       </div>
       <div class="row">
@@ -781,11 +752,8 @@
       });
     </script>
     <script>
-      function showDemoText(id) {
-        document.querySelectorAll(".demo-note").forEach((el) => {
-          el.style.display = "none";
-        });
-        const el = document.getElementById(id);
+      function showDemoText() {
+        const el = document.getElementById("demoMessage");
         if (el) {
           el.style.display = "block";
           setTimeout(() => {
@@ -795,13 +763,7 @@
       }
 
       function showDemoMessage() {
-        const el = document.getElementById("keyStatus");
-        if (el) {
-          el.style.display = "block";
-          setTimeout(() => {
-            el.style.display = "none";
-          }, 3000);
-        }
+        showDemoText();
       }
     </script>
     <script src="dashboard.js" nonce="a1b2c3"></script>


### PR DESCRIPTION
## Summary
- swap positions of AI provider section and chat demo so chat appears on the right
- replace multiple demo notices with a single reusable element
- simplify demo JavaScript helpers

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_6865bf4a9a688327a9855888f914767a