### PR TITLE
Fix chat auth header

### DIFF
--- a/chat.js
+++ b/chat.js
@@ -1,6 +1,10 @@
 (function() {
     const API_URL = '/api/scalermax-api';
-    const API_KEY = 'sk-or-REPLACE_WITH_YOUR_KEY';
+    // The API key is injected at runtime via a global variable when deployed
+    // on Netlify. Fallback to the placeholder so local demos can still work
+    // if the user manually edits this file with their key.
+    const API_KEY =
+        window.OPENROUTER_API_KEY || 'sk-or-REPLACE_WITH_YOUR_KEY';
     const REQUEST_TIMEOUT = 120000; // 2 minutes
 
     const MESSAGE_COOLDOWN_MS = 60000; // 1 minute


### PR DESCRIPTION
## Summary
- pull `OPENROUTER_API_KEY` from global on frontend
- include the key when sending chat requests

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865c09d44248327a8a916fc86673654