### PR TITLE
Remove hardcoded OpenRouter key

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ ScalerMax is a demo-ready AI Intent Server deployed on Netlify. It classifies us
 
 ## Configuration
 
-- `openrouterClient.js` includes a `HARDCODED_API_KEY` constant which is empty by default. You can populate this value if you want the demo to run without environment variables.
-- The recommended approach is to set an environment variable:
+- `openrouterClient.js` now relies solely on the `OPENROUTER_API_KEY` environment variable.
+- Set this variable before running the demo:
   ```
   OPENROUTER_API_KEY=your_openrouter_key
   ```
@@ -135,8 +135,8 @@ Response:
   Uses `openai/4o-mini` to classify prompt intent.
 - **netlify/functions/modelSelector.js**  
   Chooses execution model based on intent.  
-- **netlify/functions/openrouterClient.js**  
-  Sends requests to OpenRouter using the API key from environment variables or `HARDCODED_API_KEY`.
+- **openrouterclient.js**
+  Sends requests to OpenRouter using the API key from environment variables.
 - **netlify/functions/config.js**  
   Loads and validates environment-driven configuration.  
 - **netlify/functions/logger.js**  

--- a/chat.js
+++ b/chat.js
@@ -1,9 +1,7 @@
 (function() {
     const API_URL = '/api/scalermax-api';
-    // The API key is injected at runtime via a global variable when deployed
-    // on Netlify. Fallback to the placeholder so local demos can still work
-    // if the user manually edits this file with their key.
-    const API_KEY = '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'; // 🔑 Your actual OpenRouter key here
+    // The API key is expected via a runtime-injected global variable.
+    const API_KEY = window.OPENROUTER_API_KEY || '';
     const REQUEST_TIMEOUT = 120000; // 2 minutes
 
     const MESSAGE_COOLDOWN_MS = 60000; // 1 minute

--- a/openrouterclient.js
+++ b/openrouterclient.js
@@ -8,16 +8,14 @@ if (!fetchFn) {
   }
 }
 
-// For demo purposes a hardcoded API key can be placed below.
-// Leave as an empty string to rely on the OPENROUTER_API_KEY environment variable.
-const HARDCODED_API_KEY = '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';
 
 async function sendRequest(model, prompt, options = {}) {
-  const apiKey = options.apiKey || process.env.OPENROUTER_API_KEY || HARDCODED_API_KEY;
+  const apiKey = options.apiKey || process.env.OPENROUTER_API_KEY;
   const url = options.url || 'https://openrouter.ai/api/v1/chat/completions';
 
-  if (!apiKey || !model || !prompt) {
-    throw new Error('Missing apiKey, model, or prompt in sendRequest()');
+  if (!apiKey) throw new Error('OpenRouter API key is missing.');
+  if (!model || !prompt) {
+    throw new Error('Missing model or prompt in sendRequest()');
   }
 
   const payload = {


### PR DESCRIPTION
## Summary
- delete hardcoded API key from openrouterclient.js and require env variable
- expect frontend API key via global variable instead of hardcoded value
- clarify README about environment variable usage

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint configuration missing)*

------
https://chatgpt.com/codex/tasks/task_e_6865c91f804c832786c784b8b5e18001