### PR TITLE
Fix API key auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,12 +91,15 @@ ScalerMax is a demo-ready AI Intent Server deployed on Netlify. It classifies us
 
 ## Configuration
 
-- `openrouterClient.js` now relies solely on the `OPENROUTER_API_KEY` environment variable.
-- Set this variable before running the demo:
-  ```
-  OPENROUTER_API_KEY=your_openrouter_key
-  ```
-  or edit `netlify/functions/config.js` to load from `process.env.OPENROUTER_API_KEY`.
+- `openrouterClient.js` relies on the `OPENROUTER_API_KEY` environment variable.
+- Set both required variables before running the demo:
+```
+OPENROUTER_API_KEY=your_real_openrouter_key
+SCALERMAX_BACKEND_KEY=abc123demo
+```
+`SCALERMAX_BACKEND_KEY` authenticates requests to the backend function and must
+match the `x-api-key` header sent by the frontend. `OPENROUTER_API_KEY` remains
+server-only for calling OpenRouter.
 
 ---
 
@@ -107,6 +110,7 @@ ScalerMax is a demo-ready AI Intent Server deployed on Netlify. It classifies us
 ```bash
 curl -X POST https://<your-site>.netlify.app/.netlify/functions/scalermax-api \
   -H "Content-Type: application/json" \
+  -H "x-api-key: abc123demo" \
   -d '{"prompt":"Write a unit test for my React component"}'
 ```
 

--- a/chat.js
+++ b/chat.js
@@ -98,9 +98,9 @@
     async function streamResponse(prompt, onData, signal) {
         const res = await fetch(API_URL, {
             method: 'POST',
-            headers: { 
+            headers: {
                 'Content-Type': 'application/json',
-                'x-api-key': API_KEY
+                'x-api-key': 'REPLACE_THIS_WITH_SCALERMAX_BACKEND_KEY'
             },
             body: JSON.stringify({ prompt }),
             signal

--- a/scalermax-api.js
+++ b/scalermax-api.js
@@ -12,7 +12,7 @@ const MAX_PROMPT_LENGTH = parseInt(process.env.MAX_PROMPT_LENGTH) || 2000;
 const MAX_TOKENS = parseInt(process.env.MAX_TOKENS) || 512;
 const RATE_LIMIT_WINDOW_MS = parseInt(process.env.RATE_LIMIT_WINDOW_MS) || 60000;
 const MAX_REQUESTS_PER_WINDOW = parseInt(process.env.MAX_REQUESTS_PER_WINDOW) || 60;
-const AUTH_API_KEY = process.env.OPENROUTER_API_KEY;
+const AUTH_API_KEY = process.env.SCALERMAX_BACKEND_KEY;
 const OPENROUTER_API_URL = process.env.OPENROUTER_API_URL || 'https://openrouter.ai/api/v1/chat/completions';
 const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY;
 


### PR DESCRIPTION
## Summary
- send backend API key header from the chat client
- validate requests against `SCALERMAX_BACKEND_KEY`
- document required `SCALERMAX_BACKEND_KEY` and update curl example

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865cb420f648327ab1bfcd0b5882306