### PR TITLE
Validate env vars in API and client

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,11 @@ ScalerMax is a demo-ready AI Intent Server deployed on Netlify. It classifies us
 - `openrouterClient.js` now relies solely on the `OPENROUTER_API_KEY` environment variable.
 - `scalermax-api.js` authenticates requests using `SCALERMAX_BACKEND_KEY`.
 - Set these variables before running the demo:
-  ```
-  OPENROUTER_API_KEY=your_openrouter_key
-  SCALERMAX_BACKEND_KEY=your_backend_key
-  ```
+```
+OPENROUTER_API_KEY=your_openrouter_key
+SCALERMAX_BACKEND_KEY=your_backend_key
+OPENROUTER_BASE_URL=https://openrouter.ai # optional
+```
   or edit `netlify/functions/config.js` to load from `process.env.OPENROUTER_API_KEY`.
 
 ---

--- a/chat.js
+++ b/chat.js
@@ -1,7 +1,10 @@
 (function () {
   const API_URL = "/api/scalermax-api";
   // The API key is expected via a runtime-injected global variable.
-  const API_KEY = window.SCALERMAX_BACKEND_KEY || "";
+  const API_KEY = window.SCALERMAX_BACKEND_KEY;
+  if (!API_KEY) {
+    console.error("❌ SCALERMAX_BACKEND_KEY not provided to client");
+  }
   const REQUEST_TIMEOUT = 120000; // 2 minutes
 
   const MESSAGE_COOLDOWN_MS = 60000; // 1 minute
@@ -112,7 +115,7 @@
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "x-api-key": API_KEY,
+        ...(API_KEY ? { "x-api-key": API_KEY } : {}),
       },
       body: JSON.stringify({ prompt }),
       signal,

--- a/config.js
+++ b/config.js
@@ -17,7 +17,11 @@ if (dotenv) {
 }
 
 if (!process.env.OPENROUTER_API_KEY) {
+  console.error('❌ Missing OPENROUTER_API_KEY in environment')
   throw new Error('FATAL: OPENROUTER_API_KEY is missing in environment.')
+}
+if (!process.env.SCALERMAX_BACKEND_KEY) {
+  console.error('❌ Missing SCALERMAX_BACKEND_KEY in environment')
 }
 
 function getConfig() {

--- a/openrouterclient.js
+++ b/openrouterclient.js
@@ -10,12 +10,15 @@ if (!fetchFn) {
 
 
 async function sendRequest(model, prompt, options = {}) {
-  const apiKey =
-    options.apiKey ||
-    process.env.OPENROUTER_API_KEY;
-  const url = options.url || 'https://openrouter.ai/api/v1/chat/completions';
+  const apiKey = options.apiKey || process.env.OPENROUTER_API_KEY;
+  const baseUrl = process.env.OPENROUTER_BASE_URL || 'https://openrouter.ai';
+  const url =
+    options.url || `${baseUrl.replace(/\/$/, '')}/api/v1/chat/completions`;
 
-  if (!apiKey) throw new Error('OpenRouter API key is missing.');
+  if (!apiKey) {
+    console.error('❌ Missing OPENROUTER_API_KEY in environment');
+    throw new Error('OpenRouter API key is missing.');
+  }
   if (!model || !prompt) {
     throw new Error('Missing model or prompt in sendRequest()');
   }

--- a/scalermax-api.js
+++ b/scalermax-api.js
@@ -21,9 +21,17 @@ const MAX_REQUESTS_PER_WINDOW =
   parseInt(process.env.MAX_REQUESTS_PER_WINDOW) || 60;
 const AUTH_API_KEY = process.env.SCALERMAX_BACKEND_KEY;
 const OPENROUTER_API_URL =
-  process.env.OPENROUTER_API_URL ||
-  "https://openrouter.ai/api/v1/chat/completions";
+  (process.env.OPENROUTER_BASE_URL || process.env.OPENROUTER_API_URL ||
+    "https://openrouter.ai") +
+  "/api/v1/chat/completions";
 const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY;
+
+if (!AUTH_API_KEY) {
+  console.error("❌ Missing SCALERMAX_BACKEND_KEY in environment");
+}
+if (!OPENROUTER_API_KEY) {
+  console.error("❌ Missing OPENROUTER_API_KEY in environment");
+}
 
 const rateLimitMap = new Map();
 


### PR DESCRIPTION
## Summary
- validate critical environment variables in `scalermax-api.js`
- surface missing key errors in `config.js` and `openrouterclient.js`
- warn in frontend if `SCALERMAX_BACKEND_KEY` is not set and only send header when present
- allow overriding OpenRouter base URL
- document optional `OPENROUTER_BASE_URL` in README

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_6865d80b36c08327aaa8e177f5f97c4c