### PR TITLE
Fix API key injection

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -768,7 +768,7 @@
     </script>
     <script src="dashboard.js" nonce="a1b2c3"></script>
     <script>
-      window.SCALERMAX_BACKEND_KEY = "🔑 injected-at-runtime-or-build"; // DO NOT COMMIT REAL KEYS
+      window.SCALERMAX_BACKEND_KEY = "{{SCALERMAX_BACKEND_KEY}}"; // replaced at build time
     </script>
     <script src="chat.js" nonce="a1b2c3"></script>
   </body>


### PR DESCRIPTION
## Summary
- inject backend key placeholder into dashboard

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865db1cb7c88327b44918b5c577395d