### PR TITLE
Implement env key injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ OPENROUTER_BASE_URL=https://openrouter.ai # optional
 ```
   or edit `netlify/functions/config.js` to load from `process.env.OPENROUTER_API_KEY`.
 
+When building the frontend, the `SCALERMAX_BACKEND_KEY` value is injected into
+`dashboard.html`. The build script automatically replaces the placeholder
+`{{SCALERMAX_BACKEND_KEY}}` with the value from your environment. Ensure this
+variable is set before running `npm run build` or deploying to Netlify.
+
 ---
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "node scripts/inject.js && vite build",
     "preview": "vite preview",
     "lint": "eslint . --ext .ts,.tsx --max-warnings=0",
     "format": "prettier --write .",

--- a/scripts/inject.js
+++ b/scripts/inject.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const path = require('path');
+
+const htmlFile = path.join(__dirname, '..', 'dashboard.html');
+const key = process.env.SCALERMAX_BACKEND_KEY;
+
+if (!key) {
+  console.error('SCALERMAX_BACKEND_KEY is not set in environment');
+  process.exit(1);
+}
+
+try {
+  let content = fs.readFileSync(htmlFile, 'utf8');
+  const placeholder = '{{SCALERMAX_BACKEND_KEY}}';
+  if (!content.includes(placeholder)) {
+    console.warn('Placeholder not found in dashboard.html');
+  } else {
+    content = content.replace(placeholder, key);
+    fs.writeFileSync(htmlFile, content);
+    console.log('Injected SCALERMAX_BACKEND_KEY into dashboard.html');
+  }
+} catch (err) {
+  console.error('Failed to inject key:', err);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- inject `SCALERMAX_BACKEND_KEY` during build
- document env key injection in the README

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find a config file)*
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6865dd5a48a0832784a363a506f9f4fd