### PR TITLE
Inject backend key at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,11 @@ OPENROUTER_BASE_URL=https://openrouter.ai # optional
 ```
   or edit `netlify/functions/config.js` to load from `process.env.OPENROUTER_API_KEY`.
 
-When building the frontend, the `SCALERMAX_BACKEND_KEY` value is injected into
-`dashboard.html`. The build script automatically replaces the placeholder
-`{{SCALERMAX_BACKEND_KEY}}` with the value from your environment. Ensure this
-variable is set before running `npm run build` or deploying to Netlify.
+The admin dashboard expects `window.SCALERMAX_BACKEND_KEY` to be defined at
+runtime. On Netlify the inline script in `dashboard.html` uses the template
+`{{ process.env.SCALERMAX_BACKEND_KEY }}` which Netlify replaces with your
+environment variable value. If you build the HTML manually, run
+`node scripts/inject.js` or replace the placeholder yourself before deploying.
 
 ---
 

--- a/dashboard.html
+++ b/dashboard.html
@@ -768,7 +768,7 @@
     </script>
     <script src="dashboard.js" nonce="a1b2c3"></script>
     <script>
-      window.SCALERMAX_BACKEND_KEY = "{{SCALERMAX_BACKEND_KEY}}"; // replaced at build time
+      window.SCALERMAX_BACKEND_KEY = "{{ process.env.SCALERMAX_BACKEND_KEY }}";
     </script>
     <script src="chat.js" nonce="a1b2c3"></script>
   </body>

--- a/scalermax-api.js
+++ b/scalermax-api.js
@@ -86,6 +86,8 @@ exports.handler = async function (event, context) {
     return errorResponse(500, "Server misconfiguration: Missing API key");
   }
   const clientApiKey = headers["x-api-key"];
+  console.log("[Debug] Expected key:", AUTH_API_KEY);
+  console.log("[Debug] Received key:", clientApiKey);
   if (!clientApiKey || clientApiKey !== AUTH_API_KEY) {
     return errorResponse(
       401,

--- a/scripts/inject.js
+++ b/scripts/inject.js
@@ -11,13 +11,22 @@ if (!key) {
 
 try {
   let content = fs.readFileSync(htmlFile, 'utf8');
-  const placeholder = '{{SCALERMAX_BACKEND_KEY}}';
-  if (!content.includes(placeholder)) {
-    console.warn('Placeholder not found in dashboard.html');
-  } else {
-    content = content.replace(placeholder, key);
+  const placeholders = [
+    '{{SCALERMAX_BACKEND_KEY}}',
+    '{{ process.env.SCALERMAX_BACKEND_KEY }}'
+  ];
+  let replaced = false;
+  for (const ph of placeholders) {
+    if (content.includes(ph)) {
+      content = content.replace(ph, key);
+      replaced = true;
+    }
+  }
+  if (replaced) {
     fs.writeFileSync(htmlFile, content);
     console.log('Injected SCALERMAX_BACKEND_KEY into dashboard.html');
+  } else {
+    console.warn('Placeholder not found in dashboard.html');
   }
 } catch (err) {
   console.error('Failed to inject key:', err);


### PR DESCRIPTION
## Summary
- inject `process.env.SCALERMAX_BACKEND_KEY` directly in `dashboard.html`
- log expected and received api keys on the backend
- expand build script to replace new placeholder
- document runtime injection strategy

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm test` *(fails: vitest not found)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_e_6865de7ec1008327b4d911e8b4c259e2