### PR TITLE
Ensure backend key is always sent

### DIFF
--- a/chat.js
+++ b/chat.js
@@ -115,7 +115,7 @@
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        ...(API_KEY ? { "x-api-key": API_KEY } : {}),
+        "x-api-key": API_KEY,
       },
       body: JSON.stringify({ prompt }),
       signal,


### PR DESCRIPTION
## Summary
- send `x-api-key` header unconditionally when posting chat requests

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865e20064e08327b110314b0721e624