### PR TITLE
Implement runtime key injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,18 +95,20 @@ ScalerMax is a demo-ready AI Intent Server deployed on Netlify. It classifies us
 - `openrouterClient.js` now relies solely on the `OPENROUTER_API_KEY` environment variable.
 - `scalermax-api.js` authenticates requests using `SCALERMAX_BACKEND_KEY`.
 - Set these variables before running the demo (defaults shown where available):
+
 ```
 OPENROUTER_API_KEY=your_openrouter_key
 SCALERMAX_BACKEND_KEY=xyz789-scalermax-secret
 OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
 ```
-  or edit `netlify/functions/config.js` to load from `process.env.OPENROUTER_API_KEY`.
+
+or edit `netlify/functions/config.js` to load from `process.env.OPENROUTER_API_KEY`.
 
 The admin dashboard expects `window.SCALERMAX_BACKEND_KEY` to be defined at
 runtime. On Netlify the inline script in `dashboard.html` uses the template
 `{{ process.env.SCALERMAX_BACKEND_KEY }}` which Netlify replaces with your
-environment variable value. If you build the HTML manually, run
-`node scripts/inject.js` or replace the placeholder yourself before deploying.
+environment variable value. The development and build scripts run
+`node scripts/inject.js` automatically to perform this replacement locally.
 
 ---
 

--- a/chat.js
+++ b/chat.js
@@ -1,7 +1,10 @@
 (function () {
   const API_URL = "/api/scalermax-api";
   // The API key is expected via a runtime-injected global variable.
-  const API_KEY = window.SCALERMAX_BACKEND_KEY;
+  // Prefer the build-time injected env var with a runtime fallback
+  const API_KEY =
+    (typeof process !== "undefined" && process.env.SCALERMAX_BACKEND_KEY) ||
+    window.SCALERMAX_BACKEND_KEY;
   if (!API_KEY) {
     console.error("❌ SCALERMAX_BACKEND_KEY not provided to client");
   }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Static multi-page demo frontend for ScalerMax AI Intent Server",
   "license": "MIT",
   "scripts": {
-    "dev": "vite",
+    "dev": "node scripts/inject.js && vite",
     "build": "node scripts/inject.js && vite build",
     "preview": "vite preview",
     "lint": "eslint . --ext .ts,.tsx --max-warnings=0",

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  define: {
+    "process.env.SCALERMAX_BACKEND_KEY": JSON.stringify(
+      process.env.SCALERMAX_BACKEND_KEY,
+    ),
+  },
+});


### PR DESCRIPTION
## Summary
- inject SCALERMAX_BACKEND_KEY via Vite build
- use build-injected key in `chat.js`
- run injection script for dev as well
- document injection step in README

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint configuration missing)*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_6865e49743308327a0e2fd5f102e512f