### PR TITLE
Add debug panel and env var injection

### DIFF
--- a/chat.js
+++ b/chat.js
@@ -5,6 +5,29 @@
   const API_KEY =
     (typeof process !== "undefined" && process.env.SCALERMAX_BACKEND_KEY) ||
     window.SCALERMAX_BACKEND_KEY;
+
+  // --- DEBUG DUMP ---
+  const debugEl = document.getElementById('debug-dump');
+  function dumpDebug(obj) {
+    if (!debugEl) return;
+    debugEl.textContent = JSON.stringify(obj, null, 2);
+  }
+
+  console.groupCollapsed('🔍 SCALERMAX DEBUG');
+  console.log('window.SCALERMAX_BACKEND_KEY:', window.SCALERMAX_BACKEND_KEY);
+  console.log('window.OPENROUTER_BASE_URL :', window.OPENROUTER_BASE_URL);
+  console.log('window.OPENROUTER_API_KEY  :', window.OPENROUTER_API_KEY);
+  console.groupEnd();
+
+  dumpDebug({
+    SCALERMAX_BACKEND_KEY: window.SCALERMAX_BACKEND_KEY,
+    OPENROUTER_BASE_URL: window.OPENROUTER_BASE_URL,
+    OPENROUTER_API_KEY: window.OPENROUTER_API_KEY,
+    API_URL: API_URL,
+    CLIENT_TIME: new Date().toISOString(),
+  });
+  // ----------------------
+
   if (!API_KEY) {
     console.error("❌ SCALERMAX_BACKEND_KEY not provided to client");
   }
@@ -103,7 +126,17 @@
       if (err.name === "AbortError") {
         aiEl.textContent = "Error: Request timed out";
       } else {
-        aiEl.textContent = `⚠️ ${err.message}`;
+        const errorDetails = {
+          time: new Date().toISOString(),
+          message: err.message,
+          name: err.name,
+          stack: err.stack,
+          apiKey: API_KEY,
+          apiUrl: API_URL,
+        };
+        aiEl.textContent = '❌ Error, see debug dump below';
+        console.error('🔴 FETCH ERROR:', errorDetails);
+        dumpDebug(errorDetails);
         aiEl.classList.add("message-system");
       }
       scrollToBottom();

--- a/dashboard.html
+++ b/dashboard.html
@@ -394,6 +394,7 @@
           </div>
         </div>
       </div>
+      <pre id="debug-dump" style="background:#111;color:#0f0;padding:10px;overflow:auto;height:200px;"></pre>
       <div class="row">
         <div class="col-lg-8 order-lg-2">
           <div class="mb-2 d-flex justify-content-between align-items-center">
@@ -769,6 +770,8 @@
     <script src="dashboard.js" nonce="a1b2c3"></script>
     <script>
       window.SCALERMAX_BACKEND_KEY = "{{ process.env.SCALERMAX_BACKEND_KEY }}";
+      window.OPENROUTER_BASE_URL = "{{ process.env.OPENROUTER_BASE_URL }}";
+      window.OPENROUTER_API_KEY  = "{{ process.env.OPENROUTER_API_KEY  }}";
     </script>
     <script src="chat.js" nonce="a1b2c3"></script>
   </body>

--- a/scripts/inject.js
+++ b/scripts/inject.js
@@ -2,31 +2,41 @@ const fs = require('fs');
 const path = require('path');
 
 const htmlFile = path.join(__dirname, '..', 'dashboard.html');
-const key = process.env.SCALERMAX_BACKEND_KEY;
 
-if (!key) {
+const envVars = {
+  SCALERMAX_BACKEND_KEY: process.env.SCALERMAX_BACKEND_KEY,
+  OPENROUTER_BASE_URL: process.env.OPENROUTER_BASE_URL,
+  OPENROUTER_API_KEY: process.env.OPENROUTER_API_KEY,
+};
+
+if (!envVars.SCALERMAX_BACKEND_KEY) {
   console.error('SCALERMAX_BACKEND_KEY is not set in environment');
   process.exit(1);
 }
 
 try {
   let content = fs.readFileSync(htmlFile, 'utf8');
-  const placeholders = [
-    '{{SCALERMAX_BACKEND_KEY}}',
-    '{{ process.env.SCALERMAX_BACKEND_KEY }}'
-  ];
   let replaced = false;
-  for (const ph of placeholders) {
-    if (content.includes(ph)) {
-      content = content.replace(ph, key);
-      replaced = true;
+
+  for (const [envKey, value] of Object.entries(envVars)) {
+    const placeholders = [
+      `{{${envKey}}}`,
+      `{{ process.env.${envKey} }}`,
+    ];
+
+    for (const ph of placeholders) {
+      if (content.includes(ph)) {
+        content = content.replace(ph, value || '');
+        replaced = true;
+      }
     }
   }
+
   if (replaced) {
     fs.writeFileSync(htmlFile, content);
-    console.log('Injected SCALERMAX_BACKEND_KEY into dashboard.html');
+    console.log('Injected environment variables into dashboard.html');
   } else {
-    console.warn('Placeholder not found in dashboard.html');
+    console.warn('Placeholders not found in dashboard.html');
   }
 } catch (err) {
   console.error('Failed to inject key:', err);


### PR DESCRIPTION
## Summary
- expose OpenRouter variables in `dashboard.html`
- show a debug dump panel in `dashboard.html`
- log environment details in `chat.js` and dump fetch error details
- update injection script to also inject OpenRouter variables

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6865e988e4388327ad1a90b04008f95c