### PR TITLE
Enable chat input on dashboard

### DIFF
--- a/chat.js
+++ b/chat.js
@@ -1,6 +1,6 @@
 (function () {
   const API_URL = "/api/scalermax-api";
-  const API_KEY = import.meta.env.VITE_SCALERMAX_BACKEND_KEY;
+  const API_KEY = window.SCALERMAX_BACKEND_KEY;
 
   // --- DEBUG DUMP ---
   const debugEl = document.getElementById('debug-dump');
@@ -10,7 +10,7 @@
   }
 
   console.groupCollapsed('🔍 SCALERMAX DEBUG');
-  console.log('VITE_SCALERMAX_BACKEND_KEY:', API_KEY);
+  console.log('SCALERMAX_BACKEND_KEY:', API_KEY);
   console.log('window.OPENROUTER_BASE_URL :', window.OPENROUTER_BASE_URL);
   console.log('window.OPENROUTER_API_KEY  :', window.OPENROUTER_API_KEY);
   console.groupEnd();

--- a/dashboard.html
+++ b/dashboard.html
@@ -771,6 +771,8 @@
     <script>
       window.OPENROUTER_BASE_URL = "{{ process.env.OPENROUTER_BASE_URL }}";
       window.OPENROUTER_API_KEY  = "{{ process.env.OPENROUTER_API_KEY  }}";
+      window.SCALERMAX_BACKEND_KEY =
+        "{{ process.env.VITE_SCALERMAX_BACKEND_KEY }}";
     </script>
     <script src="chat.js" nonce="a1b2c3"></script>
   </body>


### PR DESCRIPTION
## Summary
- fix chat.js so it's executable without Vite by reading window.SCALERMAX_BACKEND_KEY
- expose SCALERMAX_BACKEND_KEY on dashboard page

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865f7677afc83278e9e566d58321c60