### PR TITLE
Use Vite env variable for API key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+OPENROUTER_API_KEY=your_openrouter_key
+VITE_SCALERMAX_BACKEND_KEY=xyz789-scalermax-secret
+OPENROUTER_BASE_URL=https://openrouter.ai/api/v1

--- a/chat.js
+++ b/chat.js
@@ -1,6 +1,9 @@
 (function () {
   const API_URL = "/api/scalermax-api";
-  const API_KEY = window.SCALERMAX_BACKEND_KEY;
+  const API_KEY = import.meta.env.VITE_SCALERMAX_BACKEND_KEY;
+  if (!API_KEY) {
+    console.error("❌ Missing VITE_SCALERMAX_BACKEND_KEY");
+  }
 
   // --- DEBUG DUMP ---
   const debugEl = document.getElementById('debug-dump');
@@ -10,23 +13,19 @@
   }
 
   console.groupCollapsed('🔍 SCALERMAX DEBUG');
-  console.log('SCALERMAX_BACKEND_KEY:', API_KEY);
+  console.log('VITE_SCALERMAX_BACKEND_KEY:', API_KEY);
   console.log('window.OPENROUTER_BASE_URL :', window.OPENROUTER_BASE_URL);
   console.log('window.OPENROUTER_API_KEY  :', window.OPENROUTER_API_KEY);
   console.groupEnd();
 
   dumpDebug({
-    SCALERMAX_BACKEND_KEY: API_KEY,
+    VITE_SCALERMAX_BACKEND_KEY: API_KEY,
     OPENROUTER_BASE_URL: window.OPENROUTER_BASE_URL,
     OPENROUTER_API_KEY: window.OPENROUTER_API_KEY,
     API_URL: API_URL,
     CLIENT_TIME: new Date().toISOString(),
   });
   // ----------------------
-
-  if (!API_KEY) {
-    console.error("❌ SCALERMAX_BACKEND_KEY not provided to client");
-  }
   const REQUEST_TIMEOUT = 120000; // 2 minutes
 
   const MESSAGE_COOLDOWN_MS = 60000; // 1 minute

--- a/dashboard.html
+++ b/dashboard.html
@@ -771,8 +771,6 @@
     <script>
       window.OPENROUTER_BASE_URL = "{{ process.env.OPENROUTER_BASE_URL }}";
       window.OPENROUTER_API_KEY  = "{{ process.env.OPENROUTER_API_KEY  }}";
-      window.SCALERMAX_BACKEND_KEY =
-        "{{ process.env.VITE_SCALERMAX_BACKEND_KEY }}";
     </script>
     <script src="chat.js" nonce="a1b2c3"></script>
   </body>


### PR DESCRIPTION
## Summary
- source `VITE_SCALERMAX_BACKEND_KEY` from `import.meta.env` in the chat client
- remove the injected API key snippet from `dashboard.html`
- document environment variables in `.env.example`

## Testing
- `npm test` *(fails: `vitest` not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_6865f8fd180083278323de196a94c41a