### PR TITLE
Fix planning router model

### DIFF
--- a/scalermax-api.js
+++ b/scalermax-api.js
@@ -74,7 +74,7 @@ function classifyPrompt(prompt) {
 
 const ROUTER_CONFIG = {
   coding: { model: process.env.CODING_MODEL || "openai/o4-mini-high" },
-  planning: { model: process.env.PLANNING_MODEL || "openai/4o-mini" },
+  planning: { model: process.env.PLANNING_MODEL || "openai/gpt-4o-mini" },
 };
 
 exports.handler = async function (event, context) {


### PR DESCRIPTION
## Summary
- update `ROUTER_CONFIG` default for planning model to `openai/gpt-4o-mini`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_6865ffd4167c83279cdacef13e5cc452