### PR TITLE
Adjust dashboard layout

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -173,7 +173,7 @@
         border-radius: 1rem;
         padding: 3rem 1.5rem;
         margin: 2rem auto;
-        max-width: 800px;
+        max-width: 550px;
         text-align: center;
       }
 
@@ -252,7 +252,7 @@
       }
 
       .chat-wrapper {
-        max-width: 600px;
+        max-width: 450px;
         margin: 0 auto;
       }
     </style>
@@ -311,7 +311,7 @@
     </aside>
     <main role="main" class="container-fluid">
       <div class="row mb-4">
-        <div class="col-lg-6">
+        <div class="col-lg-6 order-lg-2">
           <section class="highlight-box">
             <div class="highlight-inner">
               <h2>Connect Your AI Provider</h2>
@@ -359,7 +359,7 @@
             </div>
           </section>
         </div>
-        <div class="col-lg-6">
+        <div class="col-lg-6 order-lg-1">
           <div class="chat-wrapper mb-4 text-center">
             <h2>Chat Demo</h2>
             <div class="card chat-card text-light">


### PR DESCRIPTION
## Summary
- resize highlight and chat tiles
- swap chat tile to the left of the AI provider tile for a two-column layout

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68660c25e85883278937be01334b0fe9