### PR TITLE
Fix dashboard layout for provider panel

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -356,7 +356,6 @@
                 <!-- demoMessage reused for key status -->
               </div>
             </div>
-          </div>
         </section>
         <section class="chat-panel">
           <div class="chat-wrapper mb-4 text-center">


### PR DESCRIPTION
## Summary
- fix extra closing `div` causing chat panel to drop below provider panel
- ensure layout uses flexbox to show provider panel and chat side by side

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find configuration file)*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_6866112f55508327957dbfc80197e22d