### PR TITLE
Fix hero offset below fixed header

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
         </nav>
       </div>
     </header>
-    <main style="padding-top: 200px;">
+    <main>
       <section
         class="hero"
         data-animation="fade-up"

--- a/styles.css
+++ b/styles.css
@@ -24,6 +24,8 @@
 html {
   font-size: 16px;
   scroll-behavior: smooth;
+  /* ensure any anchor-link or scrollIntoView respects the fixed header */
+  scroll-padding-top: 4rem;
 }
 body {
   font-family: var(--font-sans);
@@ -480,6 +482,8 @@ button:focus,
 .hero {
   position: relative;
   min-height: 60vh;
+  /* push hero content below the fixed header */
+  padding-top: 4rem;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -500,6 +504,9 @@ button:focus,
   font-size: 3rem;
   margin-bottom: 1rem;
   color: #fff;
+  /* keep the title anchored just below the header */
+  position: relative;
+  top: 0;
 }
 
 .hero-subtitle {


### PR DESCRIPTION
## Summary
- ensure page offsets anchor jumps for the fixed header
- add padding to hero section and anchor hero title
- remove inline padding from `main` element

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68662025c000832788de91168f8819db