### PR TITLE
Remove dashboard from nav menu

### DIFF
--- a/headernav.js
+++ b/headernav.js
@@ -114,8 +114,8 @@
     if (!navMenu) return;
     const dashboardItem = navMenu.querySelector('[data-dashboard-link]');
     if (!dashboardItem) return;
-    const hasToken = document.cookie.split(';').some(c => c.trim().startsWith('authToken='));
-    dashboardItem.style.display = hasToken ? '' : 'none';
+    // Always hide the dashboard link so the main menu only shows Login
+    dashboardItem.style.display = 'none';
   }
 
   function navigateTo(route, shouldPush = true, shouldScroll = true) {


### PR DESCRIPTION
## Summary
- always hide dashboard link in main navigation

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68662c905690832794b12896fc9d443e