### PR TITLE
Use Vite env for API key

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -6,7 +6,6 @@
   <title>
 ScalerMax Admin Dashboard</title>
   <meta property="og:title" content="ScalerMax Admin Dashboard">
-  <meta name="scalermax-backend-key" content="xyz789-scalermax-secret">
   <link href="https://fonts.googleapis.com/css?family=Inter:400,500,600&display=swap" rel="stylesheet">
   <style>
     * {box-sizing:border-box;margin:0;padding:0;}

--- a/chat.js
+++ b/chat.js
@@ -1,13 +1,7 @@
 (function () {
   const API_URL = "/api/scalermax-api";
-  const metaKey =
-    document
-      .querySelector('meta[name="scalermax-backend-key"]')
-      ?.getAttribute('content');
-  let API_KEY = window.VITE_SCALERMAX_BACKEND_KEY;
-  if (!API_KEY || API_KEY.includes("{{")) {
-    API_KEY = metaKey || 'xyz789-scalermax-secret';
-  }
+  const API_KEY =
+    import.meta.env.VITE_SCALERMAX_BACKEND_KEY || "xyz789-scalermax-secret";
   if (!API_KEY) {
     console.error("❌ Missing VITE_SCALERMAX_BACKEND_KEY");
   }

--- a/dashboard.html
+++ b/dashboard.html
@@ -764,14 +764,9 @@
         showDemoText();
       }
     </script>
-    <meta name="scalermax-backend-key" content="xyz789-scalermax-secret" />
     <script src="dashboard.js" nonce="a1b2c3"></script>
     <script>
       window.OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
-      window.VITE_SCALERMAX_BACKEND_KEY =
-        document
-          .querySelector('meta[name="scalermax-backend-key"]')
-          .getAttribute('content');
     </script>
     <script src="chat.js" nonce="a1b2c3"></script>
   </body>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,6 @@
     <meta property="og:url" content="https://scalermax-fe.netlify.app/" />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="scalermax-backend-key" content="xyz789-scalermax-secret" />
     <link rel="preconnect" href="https://fonts.gstatic.com" />
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap"

--- a/login.html
+++ b/login.html
@@ -5,7 +5,6 @@
   <title>Login | ScalerMax</title>
   <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self';">
   <meta property="og:title" content="Login | ScalerMax">
-  <meta name="scalermax-backend-key" content="xyz789-scalermax-secret">
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- read API key from `import.meta.env` in chat client
- drop HTML meta key tags and the injection snippet

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_686637f935cc832794672f6dd3c4a9e9