### PR TITLE
Enable chat on load

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -377,13 +377,11 @@
                   placeholder="Type a message..."
                   aria-label="chat input"
                   rows="3"
-                  disabled
                 ></textarea>
                 <button
                   id="send-button"
                   class="glow-button"
                   type="submit"
-                  disabled
                 >
                   Send
                 </button>


### PR DESCRIPTION
## Summary
- remove `disabled` attributes from chat textarea and button in dashboard page

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68663d2596408327a18da678d0ac5cf5