### PR TITLE
Add gradient styling for home page buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
     <script defer src="animationsmanager.js"></script>
     <script defer src="glow.js"></script>
   </head>
-  <body>
+  <body class="home">
     <header
       class="site-header"
       data-animation="fade-up"

--- a/styles.css
+++ b/styles.css
@@ -471,6 +471,15 @@ button:focus,
   box-shadow: 0 0 10px var(--color-primary);
 }
 
+/* Gradient buttons on home page */
+.home .btn-primary {
+  background: linear-gradient(90deg, #16a34a, #9b5cf5);
+}
+
+.home .btn-primary:hover {
+  background: linear-gradient(90deg, #16a34a, #9b5cf5);
+}
+
 /* Layout helpers */
 .container {
   width: 90%;


### PR DESCRIPTION
## Summary
- mark the home page `<body>` with a `home` class
- apply a green-to-purple gradient to home page buttons

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866bc24ece08327a4cb4a6de8d4b202