### PR TITLE
Fix model names in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@
 
 ## Description
 
-ScalerMax is a demo-ready AI Intent Server deployed on Netlify. It classifies user prompts with a lightweight model (`openai/4o-mini`), routes them dynamically via OpenRouter to the optimal LLM (`openai/o4-mini-high`), and presents a static, animated admin dashboard with fake usage metrics.
+ScalerMax is a demo-ready AI Intent Server deployed on Netlify. It classifies user prompts with a lightweight model (`openai/gpt-4o-mini`), routes them dynamically via OpenRouter to the optimal LLM (`openai/o4-mini-high`), and presents a static, animated admin dashboard with fake usage metrics.
 
 ---
 
 ## Overview
 
 - **API**: Serverless endpoint at `/.netlify/functions/scalermax-api`
-- **Intent Classification**: Uses `openai/4o-mini`
+- **Intent Classification**: Uses `openai/gpt-4o-mini`
 - **Execution Model**: `openai/o4-mini-high`
 - **Hosting**: Netlify Functions (Node.js), static admin UI
 - **Admin UI**: Dark-themed HTML/CSS/JS with glowing cards, animated charts, and fake metrics
@@ -59,7 +59,7 @@ ScalerMax is a demo-ready AI Intent Server deployed on Netlify. It classifies us
 1. Client POSTs `{ "prompt": "..." }` to `/.netlify/functions/scalermax-api`
 2. `scalermax-api.js` loads config & logs request
 3. `scalermax-api.js` classifies the prompt as `planning` or `coding`
-4. The API selects `openai/4o-mini` for planning or `openai/o4-mini-high` for coding
+4. The API selects `openai/gpt-4o-mini` for planning or `openai/o4-mini-high` for coding
 5. `openrouterClient.js` sends the prompt to OpenRouter, receives LLM response
 6. Response is logged and returned as `{ "output": "..." }`
 
@@ -142,8 +142,8 @@ Response:
   Netlify configuration (functions directory).
 - **netlify/functions/scalermax-api.js**  
   Entrypoint: handles requests, classification, routing, response.
-- **netlify/functions/modelClassifier.js**
-  Uses `openai/4o-mini` to classify prompt intent.
+  - **netlify/functions/modelClassifier.js**
+    Uses `openai/gpt-4o-mini` to classify prompt intent.
 - **netlify/functions/modelSelector.js**  
   Chooses execution model based on intent.
 - **openrouterclient.js**
@@ -186,7 +186,7 @@ Response:
 ## Features
 
 ? Serverless AI intent routing on Netlify Functions  
-? Lightweight classification with openai/4o-mini
+? Lightweight classification with openai/gpt-4o-mini
 ? Dynamic routing to openai/o4-mini-high for ?coding? prompts
 ? Static admin UI with glowing, animated metrics  
 ? Zero build step?deploy static files & functions directly


### PR DESCRIPTION
## Summary
- correct planning model to use `openai/gpt-4o-mini` in docs

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866d0a96f2c83278f833273f8c11b4c